### PR TITLE
Fix false silence warning: use interleaved buffer for peak detection

### DIFF
--- a/swift/Sources/AudioCapture.swift
+++ b/swift/Sources/AudioCapture.swift
@@ -362,6 +362,7 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
         guard status == noErr else { return }
 
         // Convert non-interleaved → interleaved if needed, then write
+        var peakBuffer: AVAudioPCMBuffer = pcmBuffer
         do {
             if sampleFormat.isInterleaved {
                 try audioFile.write(from: pcmBuffer)
@@ -379,6 +380,7 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
                     guard let outBuffer = AVAudioPCMBuffer(pcmFormat: outFmt, frameCapacity: frameCount) else { return }
                     try converter.convert(to: outBuffer, from: pcmBuffer)
                     try audioFile.write(from: outBuffer)
+                    peakBuffer = outBuffer
                 }
             }
         } catch {
@@ -387,9 +389,10 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
 
         totalFrames += Int64(frameCount)
 
-        // Peak detection on float channel data
-        let bufferPeak: Float = pcmBuffer.floatChannelData.map {
-            computePeakLevel(in: $0, channels: Int(sampleFormat.channelCount), frames: Int(frameCount))
+        // Peak detection on the converted (interleaved) buffer — the raw capture
+        // buffer may be non-interleaved, where floatChannelData returns nil
+        let bufferPeak: Float = peakBuffer.floatChannelData.map {
+            computePeakLevel(in: $0, channels: Int(peakBuffer.format.channelCount), frames: Int(peakBuffer.frameLength))
         } ?? 0.0
         if bufferPeak > self.peakLevel { self.peakLevel = bufferPeak }
 


### PR DESCRIPTION
## Summary

- SCStream delivers audio in non-interleaved format, where `AVAudioPCMBuffer.floatChannelData` returns `nil`
- Peak detection was reading from the raw capture buffer, always getting `0.0`, causing `[SILENCE_WARNING]` to fire even when audio was being captured normally
- Fix: use the converted interleaved buffer for peak detection instead of the raw capture buffer

## Root cause

In `stream(_:didOutputSampleBuffer:of:)`, peak detection reads `pcmBuffer.floatChannelData` — but `pcmBuffer` uses the format from SCStream which is non-interleaved. For non-interleaved buffers, `floatChannelData` returns `nil`, so the `?? 0.0` fallback always fires. The interleaved buffer (`outBuffer`) created by the converter has valid `floatChannelData`.

## Test plan

- [x] Record with system audio playing — no more false `[SILENCE_WARNING]`
- [x] Silence timeout still works correctly (uses the same peak value)
- [x] Genuine silence (no audio playing) still triggers the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)