### PR TITLE
Reduce system audio capture to 24kHz mono (~4x smaller files)

### DIFF
--- a/swift/Sources/AudioCapture.swift
+++ b/swift/Sources/AudioCapture.swift
@@ -618,22 +618,26 @@ func mergeAudioFiles(systemPath: String, micPath: String,
         // Read and mix system audio (manual interleave from non-interleaved processingFormat)
         if let systemFile = systemFile {
             let sysFrameInFile = (offsetFrames >= 0) ? outputFrame : outputFrame + offsetFrames
-            if sysFrameInFile >= 0 && sysFrameInFile < systemLength {
-                let sysReadCount = AVAudioFrameCount(min(Int64(framesToProcess), systemLength - sysFrameInFile))
+            let writeOffset = max(0, -sysFrameInFile)
+            let readStart = max(0, sysFrameInFile)
+            if readStart < systemLength && writeOffset < Int64(framesToProcess) {
+                let maxRead = Int64(framesToProcess) - writeOffset
+                let sysReadCount = AVAudioFrameCount(min(maxRead, systemLength - readStart))
                 if sysReadCount > 0 {
-                    systemFile.framePosition = AVAudioFramePosition(sysFrameInFile)
+                    systemFile.framePosition = AVAudioFramePosition(readStart)
                     if let sysBuf = AVAudioPCMBuffer(pcmFormat: systemFile.processingFormat, frameCapacity: sysReadCount) {
                         try systemFile.read(into: sysBuf, frameCount: sysReadCount)
                         let sysData = sysBuf.floatChannelData!
                         let sysCh = Int(sysBuf.format.channelCount)
+                        let wo = Int(writeOffset)
                         for i in 0..<Int(sysBuf.frameLength) {
                             if outputChannels == 1 {
                                 var mix: Float = 0
                                 for ch in 0..<sysCh { mix += sysData[ch][i] }
-                                outPtr[i] += mix / Float(sysCh)
+                                outPtr[wo + i] += mix / Float(sysCh)
                             } else {
-                                outPtr[i * 2] += sysData[0][i]
-                                outPtr[i * 2 + 1] += sysCh > 1 ? sysData[1][i] : sysData[0][i]
+                                outPtr[(wo + i) * 2] += sysData[0][i]
+                                outPtr[(wo + i) * 2 + 1] += sysCh > 1 ? sysData[1][i] : sysData[0][i]
                             }
                         }
                     }

--- a/swift/Sources/AudioCapture.swift
+++ b/swift/Sources/AudioCapture.swift
@@ -271,15 +271,15 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
         let config = SCStreamConfiguration()
         config.capturesAudio = true
         config.excludesCurrentProcessAudio = true
-        config.sampleRate = 48000
-        config.channelCount = 2
+        config.sampleRate = 24000
+        config.channelCount = 1
         config.width = 2
         config.height = 2
         config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
         config.showsCursor = false
 
         // Create AVAudioFile for WAV output (interleaved to avoid CoreAudio warning)
-        let fileFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48000, channels: 2, interleaved: true)!
+        let fileFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 24000, channels: 1, interleaved: true)!
         let audioFile = try AVAudioFile(forWriting: URL(fileURLWithPath: outputPath),
                                          settings: fileFormat.settings,
                                          commonFormat: .pcmFormatFloat32,
@@ -401,7 +401,7 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
         }
 
         // Check for silence after ~3 seconds of data
-        if !silenceChecked && totalFrames > 48000 * 3 {
+        if !silenceChecked && totalFrames > 24000 * 3 {
             silenceChecked = true
             if peakLevel < 1e-6 {
                 silenceWarned = true
@@ -433,7 +433,7 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
         // AVAudioFile finalizes on close
         audioFile = nil
 
-        let seconds = Double(totalFrames) / 48000.0
+        let seconds = Double(totalFrames) / 24000.0
         fputs("Saved \(outputPath) (\(String(format: "%.1f", seconds)) seconds, peak=\(String(format: "%.6f", peakLevel)))\n", stderr)
         if totalFrames > 0 && peakLevel < 1e-6 {
             fputs("[SILENCE_WARNING] Recording appears silent. Check Screen Recording permission.\n", stderr)
@@ -557,8 +557,8 @@ func mergeAudioFiles(systemPath: String, micPath: String,
         ? try AVAudioFile(forReading: URL(fileURLWithPath: systemPath)) : nil
     let micFile = try AVAudioFile(forReading: URL(fileURLWithPath: micPath))
 
-    let outputSampleRate: Double = 48000
-    let outputChannels: AVAudioChannelCount = 2
+    let outputSampleRate: Double = 24000
+    let outputChannels: AVAudioChannelCount = 1
 
     // Compute offset in seconds between the two start times using mach_timebase_info
     let offsetFrames: Int64
@@ -625,9 +625,16 @@ func mergeAudioFiles(systemPath: String, micPath: String,
                     if let sysBuf = AVAudioPCMBuffer(pcmFormat: systemFile.processingFormat, frameCapacity: sysReadCount) {
                         try systemFile.read(into: sysBuf, frameCount: sysReadCount)
                         let sysData = sysBuf.floatChannelData!
+                        let sysCh = Int(sysBuf.format.channelCount)
                         for i in 0..<Int(sysBuf.frameLength) {
-                            outPtr[i * 2] += sysData[0][i]
-                            outPtr[i * 2 + 1] += sysData[1][i]
+                            if outputChannels == 1 {
+                                var mix: Float = 0
+                                for ch in 0..<sysCh { mix += sysData[ch][i] }
+                                outPtr[i] += mix / Float(sysCh)
+                            } else {
+                                outPtr[i * 2] += sysData[0][i]
+                                outPtr[i * 2 + 1] += sysCh > 1 ? sysData[1][i] : sysData[0][i]
+                            }
                         }
                     }
                 }

--- a/swift/Sources/AudioCapture.swift
+++ b/swift/Sources/AudioCapture.swift
@@ -13,6 +13,8 @@ import AudioToolbox
 private let kMicLoudThreshold: Float = 1e-2
 /// Minimum peak amplitude to consider system audio "loud" (silence timeout).
 private let kSystemLoudThreshold: Float = 1e-4
+/// System audio capture and merge output sample rate (mono float32).
+private let kSystemAudioSampleRate: Double = 24000
 
 /// Compute peak amplitude across all channels of float audio data.
 func computePeakLevel(in channelData: UnsafePointer<UnsafeMutablePointer<Float>>,
@@ -271,7 +273,7 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
         let config = SCStreamConfiguration()
         config.capturesAudio = true
         config.excludesCurrentProcessAudio = true
-        config.sampleRate = 24000
+        config.sampleRate = Int(kSystemAudioSampleRate)
         config.channelCount = 1
         config.width = 2
         config.height = 2
@@ -279,7 +281,7 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
         config.showsCursor = false
 
         // Create AVAudioFile for WAV output (interleaved to avoid CoreAudio warning)
-        let fileFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 24000, channels: 1, interleaved: true)!
+        let fileFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: kSystemAudioSampleRate, channels: 1, interleaved: true)!
         let audioFile = try AVAudioFile(forWriting: URL(fileURLWithPath: outputPath),
                                          settings: fileFormat.settings,
                                          commonFormat: .pcmFormatFloat32,
@@ -401,7 +403,7 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
         }
 
         // Check for silence after ~3 seconds of data
-        if !silenceChecked && totalFrames > 24000 * 3 {
+        if !silenceChecked && Double(totalFrames) > kSystemAudioSampleRate * 3 {
             silenceChecked = true
             if peakLevel < 1e-6 {
                 silenceWarned = true
@@ -433,7 +435,7 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
         // AVAudioFile finalizes on close
         audioFile = nil
 
-        let seconds = Double(totalFrames) / 24000.0
+        let seconds = Double(totalFrames) / kSystemAudioSampleRate
         fputs("Saved \(outputPath) (\(String(format: "%.1f", seconds)) seconds, peak=\(String(format: "%.6f", peakLevel)))\n", stderr)
         if totalFrames > 0 && peakLevel < 1e-6 {
             fputs("[SILENCE_WARNING] Recording appears silent. Check Screen Recording permission.\n", stderr)
@@ -557,7 +559,7 @@ func mergeAudioFiles(systemPath: String, micPath: String,
         ? try AVAudioFile(forReading: URL(fileURLWithPath: systemPath)) : nil
     let micFile = try AVAudioFile(forReading: URL(fileURLWithPath: micPath))
 
-    let outputSampleRate: Double = 24000
+    let outputSampleRate: Double = kSystemAudioSampleRate
     let outputChannels: AVAudioChannelCount = 1
 
     // Compute offset in seconds between the two start times using mach_timebase_info


### PR DESCRIPTION
## Summary

- Changed system audio capture from 48kHz stereo float32 to 24kHz mono float32
- ~4x smaller WAV files: a 1-hour meeting goes from ~1.4GB to ~330MB
- Fixed mono-incompatible stereo interleaving in the merge function

## Why

48kHz stereo float32 is studio music production quality — overkill for speech/meeting recording. WhisperX resamples to 16kHz internally anyway, so anything above 16kHz is purely for the archived WAV. 24kHz mono is well above that threshold and still sounds great for voice playback.

| Setting | Before | After |
|---------|--------|-------|
| Sample rate | 48,000 Hz | 24,000 Hz |
| Channels | 2 (stereo) | 1 (mono) |
| Format | float32 | float32 |
| Per minute | ~23 MB | ~5.5 MB |
| 1-hour meeting | ~1.4 GB | ~330 MB |

## Merge fix

The `mergeAudioFiles` function hardcoded stereo interleaving (`outPtr[i * 2]`, `sysData[1][i]`), which writes out of bounds with mono output. Updated to handle both mono and stereo output based on `outputChannels`.

## Test plan

- [x] Record with mic + system audio, verify merge produces correct mono WAV
- [x] Transcription quality unaffected (WhisperX resamples to 16kHz anyway)
- [x] Diarization works correctly on mono recordings
- [x] Silence detection thresholds updated for 24kHz

🤖 Generated with [Claude Code](https://claude.com/claude-code)