### PR TITLE
Fix silence timer crash and harden audio capture

### DIFF
--- a/swift/Sources/AudioCapture.swift
+++ b/swift/Sources/AudioCapture.swift
@@ -116,7 +116,11 @@ class MicCapture {
                     os_unfair_lock_unlock(&self._lastLoudTimeLock)
                 }
             }
-            try? self.audioFile?.write(from: buffer)
+            do {
+                try self.audioFile?.write(from: buffer)
+            } catch {
+                fputs("Mic write error: \(error)\n", stderr)
+            }
         }
         try engine.start()
         fputs("Recording microphone audio to \(outputPath)...\n", stderr)
@@ -322,6 +326,7 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
                         effectiveLastLoud = micLastLoud
                     }
                 }
+                guard now >= effectiveLastLoud else { return }
                 let elapsed = Double(now - effectiveLastLoud) / 1_000_000_000.0
                 if elapsed > self.silenceTimeout {
                     fputs("[SILENCE_TIMEOUT]\n", stderr)
@@ -370,7 +375,7 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
                 try audioFile.write(from: pcmBuffer)
             } else {
                 // Lazily create converter matching this source format
-                if audioConverter == nil || audioConverter!.inputFormat != sampleFormat {
+                if audioConverter?.inputFormat != sampleFormat {
                     let interleavedFmt = AVAudioFormat(commonFormat: .pcmFormatFloat32,
                                                        sampleRate: sampleFormat.sampleRate,
                                                        channels: sampleFormat.channelCount,

--- a/swift/Sources/AudioCapture.swift
+++ b/swift/Sources/AudioCapture.swift
@@ -369,12 +369,10 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
         guard status == noErr else { return }
 
         // Convert non-interleaved → interleaved if needed, then write
-        var peakBuffer: AVAudioPCMBuffer = pcmBuffer
         do {
             if sampleFormat.isInterleaved {
                 try audioFile.write(from: pcmBuffer)
             } else {
-                // Lazily create converter matching this source format
                 if audioConverter?.inputFormat != sampleFormat {
                     let interleavedFmt = AVAudioFormat(commonFormat: .pcmFormatFloat32,
                                                        sampleRate: sampleFormat.sampleRate,
@@ -387,7 +385,6 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
                     guard let outBuffer = AVAudioPCMBuffer(pcmFormat: outFmt, frameCapacity: frameCount) else { return }
                     try converter.convert(to: outBuffer, from: pcmBuffer)
                     try audioFile.write(from: outBuffer)
-                    peakBuffer = outBuffer
                 }
             }
         } catch {
@@ -396,10 +393,10 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
 
         totalFrames += Int64(frameCount)
 
-        // Peak detection on the converted (interleaved) buffer — the raw capture
-        // buffer may be non-interleaved, where floatChannelData returns nil
-        let bufferPeak: Float = peakBuffer.floatChannelData.map {
-            computePeakLevel(in: $0, channels: Int(peakBuffer.format.channelCount), frames: Int(peakBuffer.frameLength))
+        // Peak detection on the pre-conversion buffer — floatChannelData returns nil
+        // for interleaved buffers, so we must use the original SCK buffer
+        let bufferPeak: Float = pcmBuffer.floatChannelData.map {
+            computePeakLevel(in: $0, channels: Int(pcmBuffer.format.channelCount), frames: Int(pcmBuffer.frameLength))
         } ?? 0.0
         if bufferPeak > self.peakLevel { self.peakLevel = bufferPeak }
 
@@ -415,8 +412,12 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
             silenceChecked = true
             if peakLevel < 1e-6 {
                 silenceWarned = true
-                fputs("[SILENCE_WARNING] Audio data received but peak level is near zero (\(peakLevel)). Audio may be silent.\n", stderr)
-                fputs("Check: System Settings > Privacy & Security > Screen Recording — enable your terminal app.\n", stderr)
+                if micCapture != nil {
+                    fputs("[SILENCE_WARNING] System audio is silent (mic is still recording). No system audio sources detected.\n", stderr)
+                } else {
+                    fputs("[SILENCE_WARNING] Audio data received but peak level is near zero (\(peakLevel)). Audio may be silent.\n", stderr)
+                    fputs("Check: System Settings > Privacy & Security > Screen Recording — enable your terminal app.\n", stderr)
+                }
             }
         }
     }


### PR DESCRIPTION
## Problems

**1. Crash mid-recording (~12 min):** `ownscribe-audio` crashes with `EXC_BREAKPOINT` (SIGTRAP). The silence timeout timer captures `now`, then reads `lastLoudTime` (updated by audio callbacks at ~24K/sec on other threads). Between those two operations, a callback can set `lastLoudTime` to a value newer than `now`. The subsequent `now - lastLoudTime` underflows on UInt64 and Swift's checked arithmetic traps. Confirmed via macOS crash report.

**2. Peak detection always reports 0.0:** `peakBuffer` points to the interleaved output buffer after format conversion. `floatChannelData` returns nil for interleaved buffers, so peak is always 0.0 via the `?? 0.0` fallback. This breaks the silence warning (always fires) and the silence timeout (system audio never registers as "loud").

**3. Misleading silence warning:** "Audio may be silent" fires even when mic is actively recording both sides of a conversation — only system audio is silent, but the message implies the whole recording failed.

**4. Minor:** Mic write failures silently swallowed (`try?`), `audioConverter` force-unwrap.

## Fix

1. Guard UInt64 subtraction: `guard now >= effectiveLastLoud else { return }`
2. Use `pcmBuffer` (pre-conversion, non-interleaved from SCK) for peak detection instead of `peakBuffer`
3. When mic is active, warning says "System audio is silent (mic is still recording)" instead
4. `try?` → `try/catch` with stderr logging; `audioConverter!` → `audioConverter?`

## Test plan

- [x] 43-minute recording completed without crash (previously crashed at ~12 min)
- [x] 15-minute recording with speech-to-text running simultaneously — clean transcript
- [x] Peak detection: audio playing → 0.88 (was always 0.0 before fix)
- [x] Peak detection: nothing playing → 0.0, warning fires correctly
- [x] Silence timeout still triggers correctly
- [x] Clean build, zero new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)