### PR TITLE
Add capture_mode config to skip source picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ This will:
 3. Summarize with your local LLM
 4. Save everything to `~/ownscribe/YYYY-MM-DD_HHMMSS/`
 
+> **Note:** By default, macOS shows a source picker on each launch so you can choose what to capture. To skip it and always record all system audio, set `capture_mode = "all"` in the `[audio]` config section.
+
 On first run, WhisperX / pyannote and the summarization model may download model files. ownscribe shows a `Preparing models` step and best-effort download progress in the TUI while this happens. Use `ownscribe warmup` to pre-download all models.
 
 ### Options
@@ -187,6 +189,7 @@ backend = "coreaudio"     # "coreaudio" or "sounddevice"
 device = ""               # empty = system audio
 mic = false               # also capture microphone input
 mic_device = ""           # specific mic device name (empty = default)
+capture_mode = "picker"   # "picker" = show source picker; "all" = capture all system audio directly
 silence_timeout = 300     # seconds of silence before auto-stop; 0 = disabled
 
 [transcription]

--- a/src/ownscribe/audio/coreaudio.py
+++ b/src/ownscribe/audio/coreaudio.py
@@ -78,9 +78,10 @@ def _find_binary() -> Path | None:
 class CoreAudioRecorder(AudioRecorder):
     """Records system audio using the ownscribe-audio Swift helper."""
 
-    def __init__(self, mic: bool = False, mic_device: str = "", silence_timeout: int = 0) -> None:
+    def __init__(self, mic: bool = False, mic_device: str = "", capture_mode: str = "picker", silence_timeout: int = 0) -> None:
         self._mic = mic
         self._mic_device = mic_device
+        self._capture_mode = capture_mode
         self._silence_timeout = silence_timeout
         self._process: subprocess.Popen | None = None
         self._binary = _find_binary()
@@ -96,6 +97,8 @@ class CoreAudioRecorder(AudioRecorder):
             raise RuntimeError("ownscribe-audio binary not found. Run: bash swift/build.sh")
 
         cmd = [str(self._binary), "capture", "--output", str(output_path)]
+        if self._capture_mode == "all":
+            cmd.append("--capture-mode-all")
         if self._mic or self._mic_device:
             cmd.append("--mic")
         if self._mic_device:

--- a/src/ownscribe/audio/coreaudio.py
+++ b/src/ownscribe/audio/coreaudio.py
@@ -78,7 +78,10 @@ def _find_binary() -> Path | None:
 class CoreAudioRecorder(AudioRecorder):
     """Records system audio using the ownscribe-audio Swift helper."""
 
-    def __init__(self, mic: bool = False, mic_device: str = "", capture_mode: str = "picker", silence_timeout: int = 0) -> None:
+    def __init__(
+        self, mic: bool = False, mic_device: str = "",
+        capture_mode: str = "picker", silence_timeout: int = 0,
+    ) -> None:
         self._mic = mic
         self._mic_device = mic_device
         self._capture_mode = capture_mode

--- a/src/ownscribe/config.py
+++ b/src/ownscribe/config.py
@@ -16,6 +16,7 @@ backend = "coreaudio"     # "coreaudio" (default) or "sounddevice"
 device = ""               # empty = system audio; or device name/index for sounddevice
 mic = false               # also capture microphone input
 mic_device = ""           # specific mic device name (empty = default)
+capture_mode = "picker"   # "picker" = show source picker; "all" = capture all system audio directly
 silence_timeout = 300     # seconds of silence before auto-stop; 0 = disabled
 
 [transcription]
@@ -56,6 +57,7 @@ class AudioConfig:
     device: str = ""
     mic: bool = False
     mic_device: str = ""
+    capture_mode: str = "picker"  # "picker" = show source picker; "all" = all system audio
     silence_timeout: int = 300  # seconds of silence before auto-stop; 0 = disabled
 
 

--- a/src/ownscribe/pipeline.py
+++ b/src/ownscribe/pipeline.py
@@ -74,6 +74,7 @@ def _create_recorder(config: Config):
         recorder = CoreAudioRecorder(
             mic=config.audio.mic,
             mic_device=config.audio.mic_device,
+            capture_mode=config.audio.capture_mode,
             silence_timeout=config.audio.silence_timeout,
         )
         if recorder.is_available():

--- a/swift/Sources/AudioCapture.swift
+++ b/swift/Sources/AudioCapture.swift
@@ -225,19 +225,28 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
         super.init()
     }
 
-    func start() async throws {
-        // Configure and show the content sharing picker
-        let picker = SCContentSharingPicker.shared
-        var pickerConfig = SCContentSharingPickerConfiguration()
-        pickerConfig.allowedPickerModes = [.singleWindow, .singleDisplay, .singleApplication]
-        picker.defaultConfiguration = pickerConfig
-        picker.add(self)
-        picker.isActive = true
-        picker.present()
+    var captureModeAll: Bool = false
 
-        // Suspend until the picker delegate fires
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            self.startContinuation = continuation
+    func start() async throws {
+        if captureModeAll {
+            let content = try await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: false)
+            guard let display = content.displays.first else {
+                throw CaptureError.noDisplay
+            }
+            let filter = SCContentFilter(display: display, excludingApplications: [], exceptingWindows: [])
+            try await self.beginCapture(with: filter)
+        } else {
+            let picker = SCContentSharingPicker.shared
+            var pickerConfig = SCContentSharingPickerConfiguration()
+            pickerConfig.allowedPickerModes = [.singleWindow, .singleDisplay, .singleApplication]
+            picker.defaultConfiguration = pickerConfig
+            picker.add(self)
+            picker.isActive = true
+            picker.present()
+
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                self.startContinuation = continuation
+            }
         }
     }
 
@@ -726,6 +735,7 @@ func printUsage() {
         --output, -o FILE    Output WAV file path (required for capture)
         --mic                Also capture microphone input
         --mic-device NAME    Use specific mic input device (implies --mic)
+        --capture-mode-all   Capture all system audio without showing the source picker
         --silence-timeout N  Auto-stop after N seconds of silence (0 = disabled)
         --help, -h           Show this help
 
@@ -761,6 +771,7 @@ func main() {
         var outputPath: String?
         var enableMic = false
         var micDeviceName: String?
+        var captureModeAll = false
         var silenceTimeout: TimeInterval = 0
 
         var i = 2
@@ -773,6 +784,8 @@ func main() {
                     exit(1)
                 }
                 outputPath = args[i]
+            case "--capture-mode-all":
+                captureModeAll = true
             case "--mic":
                 enableMic = true
             case "--mic-device":
@@ -813,6 +826,7 @@ func main() {
         let micPath = output + ".mic.tmp.wav"
 
         let capture = SystemAudioCapture(outputPath: systemPath)
+        capture.captureModeAll = captureModeAll
         capture.silenceTimeout = silenceTimeout
         var micCapture: MicCapture?
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -60,7 +60,20 @@ class TestCreateRecorder:
         with mock.patch("ownscribe.audio.coreaudio.CoreAudioRecorder") as mock_cls:
             mock_cls.return_value.is_available.return_value = True
             _create_recorder(config)
-            mock_cls.assert_called_once_with(mic=False, mic_device="", silence_timeout=120)
+            mock_cls.assert_called_once_with(mic=False, mic_device="", capture_mode="picker", silence_timeout=120)
+
+    def test_capture_mode_passed_to_coreaudio(self):
+        from ownscribe.pipeline import _create_recorder
+
+        config = Config()
+        config.audio.backend = "coreaudio"
+        config.audio.device = ""
+        config.audio.capture_mode = "all"
+
+        with mock.patch("ownscribe.audio.coreaudio.CoreAudioRecorder") as mock_cls:
+            mock_cls.return_value.is_available.return_value = True
+            _create_recorder(config)
+            mock_cls.assert_called_once_with(mic=False, mic_device="", capture_mode="all", silence_timeout=300)
 
     def test_silence_timeout_passed_to_sounddevice(self):
         from ownscribe.pipeline import _create_recorder


### PR DESCRIPTION
## Problem

Every time `ownscribe` starts, the macOS `SCContentSharingPicker` dialog pops up asking which window/display/app to capture. For a meeting recorder that just wants all system audio, this adds unnecessary friction on every launch. There's no way to skip it.

Additionally, the picker flow requires "Screen & System Audio Recording" permission, when ownscribe only needs "System Audio Recording Only" since it doesn't capture video.

## Fix

New `capture_mode` config option in the `[audio]` section:

- `"picker"` (default): show the picker — existing behavior, no breaking change
- `"all"`: capture all system audio directly via `SCShareableContent`, skipping the picker

```toml
[audio]
capture_mode = "all"
```

The Swift binary accepts `--capture-mode-all` flag, passed by the Python wrapper when configured.

Closes #18

## Test plan

- [x] `capture_mode = "all"` with audio playing — captures correctly (peak 0.88)
- [x] `capture_mode = "all"` with nothing playing — silence warning fires correctly
- [x] `capture_mode = "picker"` (default) — picker shows, captures after selection
- [x] Config defaults to `"picker"` when not specified
- [x] New test: `test_capture_mode_passed_to_coreaudio` verifies "all" flows through
- [x] Lint + tests pass

## Remaining Todo
- [x] Document config and flag in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)