### PR TITLE
WIP: Add crash resilience: stream error handling, watchdog, and recovery

### DIFF
--- a/src/ownscribe/audio/coreaudio.py
+++ b/src/ownscribe/audio/coreaudio.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import platform
 import shutil
 import signal
@@ -13,6 +14,16 @@ from pathlib import Path
 import click
 
 from ownscribe.audio.base import AudioRecorder
+
+logger = logging.getLogger(__name__)
+
+_WAV_HEADER_SIZE = 44
+
+# Stderr markers emitted by the Swift helper (keep in sync with AudioCapture.swift)
+_MARKER_SILENCE_WARNING = "[SILENCE_WARNING]"
+_MARKER_SILENCE_TIMEOUT = "[SILENCE_TIMEOUT]"
+_MARKER_STREAM_ERROR = "[STREAM_ERROR]"
+_MARKER_STREAM_DIED = "[STREAM_DIED]"
 
 # Timeouts for graceful shutdown of the Swift helper.
 # SIGINT triggers track merging (system + mic) which can take a while for long recordings.
@@ -87,6 +98,10 @@ class CoreAudioRecorder(AudioRecorder):
         self._silence_warning: bool = False
         self._silence_timed_out: bool = False
         self._muted: bool = False
+        self._output_path: Path | None = None
+        self._crashed: bool = False
+        self._exit_code: int | None = None
+        self._stderr_output: str = ""
 
     def is_available(self) -> bool:
         return self._binary is not None
@@ -95,6 +110,7 @@ class CoreAudioRecorder(AudioRecorder):
         if not self._binary:
             raise RuntimeError("ownscribe-audio binary not found. Run: bash swift/build.sh")
 
+        self._output_path = output_path
         cmd = [str(self._binary), "capture", "--output", str(output_path)]
         if self._mic or self._mic_device:
             cmd.append("--mic")
@@ -133,8 +149,22 @@ class CoreAudioRecorder(AudioRecorder):
     def silence_timed_out(self) -> bool:
         return self._silence_timed_out
 
+    @property
+    def crashed(self) -> bool:
+        return self._crashed
+
+    @property
+    def exit_code(self) -> int | None:
+        return self._exit_code
+
+    @property
+    def stderr_output(self) -> str:
+        return self._stderr_output
+
     def stop(self) -> None:
-        if self._process and self._process.poll() is None:
+        rc = self._process.poll() if self._process else None
+
+        if rc is None and self._process:
             self._process.send_signal(signal.SIGINT)
             try:
                 self._process.wait(timeout=_STOP_TIMEOUT)
@@ -145,23 +175,95 @@ class CoreAudioRecorder(AudioRecorder):
                 except subprocess.TimeoutExpired:
                     self._process.kill()
                     self._process.wait()
-        if self._process and self._process.stderr:
-            stderr_output = self._process.stderr.read().decode(errors="replace")
-            if stderr_output:
-                if "[SILENCE_WARNING]" in stderr_output:
-                    self._silence_warning = True
-                if "[SILENCE_TIMEOUT]" in stderr_output:
-                    self._silence_timed_out = True
-                # Filter out mute toggles and known informational lines
-                _NOISE_PREFIXES = ("Recording ", "Saved ", "Merged audio saved")
-                _NOISE_LINES = ("[MIC_MUTED]", "[MIC_UNMUTED]", "[SILENCE_TIMEOUT]")
-                lines = [
-                    line for line in stderr_output.strip().splitlines()
-                    if line not in _NOISE_LINES
-                    and not line.startswith(_NOISE_PREFIXES)
-                ]
-                if lines:
-                    click.echo("\n".join(lines), err=True)
+
+        if self._process:
+            self._exit_code = self._process.returncode
+            self._finalize_stderr()
+
+        if self._crashed:
+            self._attempt_recovery()
+
+    def _finalize_stderr(self) -> None:
+        if not self._process or not self._process.stderr:
+            return
+        self._stderr_output = self._process.stderr.read().decode(errors="replace")
+        if not self._stderr_output:
+            return
+
+        if _MARKER_SILENCE_WARNING in self._stderr_output:
+            self._silence_warning = True
+        if _MARKER_SILENCE_TIMEOUT in self._stderr_output:
+            self._silence_timed_out = True
+        if _MARKER_STREAM_ERROR in self._stderr_output or _MARKER_STREAM_DIED in self._stderr_output:
+            self._crashed = True
+        if self._exit_code is not None and self._exit_code != 0:
+            self._crashed = True
+
+        _NOISE_PREFIXES = ("Recording ", "Saved ", "Merged audio saved")
+        _NOISE_LINES = (_MARKER_SILENCE_TIMEOUT, "[MIC_MUTED]", "[MIC_UNMUTED]")
+        lines = [
+            line for line in self._stderr_output.strip().splitlines()
+            if line not in _NOISE_LINES
+            and not line.startswith(_NOISE_PREFIXES)
+        ]
+        if lines:
+            click.echo("\n".join(lines), err=True)
+
+    def _attempt_recovery(self) -> None:
+        if not self._output_path:
+            return
+        output = self._output_path
+
+        if output.exists() and output.stat().st_size > _WAV_HEADER_SIZE:
+            return
+
+        sys_tmp = Path(str(output) + ".sys.tmp.wav")
+        mic_tmp = Path(str(output) + ".mic.tmp.wav")
+        has_sys = sys_tmp.exists() and sys_tmp.stat().st_size > _WAV_HEADER_SIZE
+        has_mic = mic_tmp.exists() and mic_tmp.stat().st_size > _WAV_HEADER_SIZE
+
+        if not has_sys and not has_mic:
+            return
+        if not shutil.which("ffmpeg"):
+            logger.warning("ffmpeg not found — cannot recover audio from tmp files")
+            return
+
+        click.echo("\n  Recovering audio from temp files...", err=True)
+        try:
+            if has_sys and has_mic:
+                subprocess.run(
+                    [
+                        "ffmpeg", "-y", "-loglevel", "error",
+                        "-i", str(mic_tmp), "-i", str(sys_tmp),
+                        "-filter_complex",
+                        "[0:a]aresample=24000[mic];[mic][1:a]amix=inputs=2:duration=longest[out]",
+                        "-map", "[out]", "-ar", "24000", "-ac", "1",
+                        "-c:a", "pcm_f32le", str(output),
+                    ],
+                    check=True, capture_output=True,
+                )
+            elif has_sys:
+                sys_tmp.rename(output)
+            elif has_mic:
+                subprocess.run(
+                    [
+                        "ffmpeg", "-y", "-loglevel", "error",
+                        "-i", str(mic_tmp), "-ar", "24000", "-ac", "1",
+                        "-c:a", "pcm_f32le", str(output),
+                    ],
+                    check=True, capture_output=True,
+                )
+
+            if output.exists() and output.stat().st_size > _WAV_HEADER_SIZE:
+                sys_tmp.unlink(missing_ok=True)
+                mic_tmp.unlink(missing_ok=True)
+                click.echo("  Audio recovered successfully.", err=True)
+            else:
+                click.echo("  Recovery produced empty file.", err=True)
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.decode(errors="replace") if e.stderr else ""
+            logger.warning("ffmpeg recovery failed: %s", stderr)
+            click.echo(f"  Recovery failed: {stderr}", err=True)
 
     def list_devices(self) -> str:
         """List available audio devices using the Swift helper."""

--- a/src/ownscribe/pipeline.py
+++ b/src/ownscribe/pipeline.py
@@ -29,6 +29,21 @@ from ownscribe.summarization import create_summarizer
 _WAV_HEADER_SIZE = 44
 
 
+def _log_crash(out_dir: Path, exit_code: int | None, stderr_output: str, elapsed: float) -> None:
+    crash_log = out_dir / "crash.log"
+    mins, secs = divmod(int(elapsed), 60)
+    lines = [
+        f"Recording crashed at {mins:02d}:{secs:02d}",
+        f"Time: {datetime.now().isoformat()}",
+        f"Exit code: {exit_code}",
+        "",
+        "--- stderr ---",
+        stderr_output.strip() if stderr_output else "(empty)",
+    ]
+    crash_log.write_text("\n".join(lines) + "\n")
+    click.echo(f"  Crash log saved to {crash_log}", err=True)
+
+
 def _check_audio_silence(audio_path: Path) -> None:
     """Check if the recorded audio is silent and warn the user."""
     try:
@@ -230,8 +245,20 @@ def run_pipeline(config: Config) -> None:
             termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_termios)
         signal.signal(signal.SIGINT, original_handler)
 
+    elapsed = time.time() - start_time
     recorder.stop()
-    if getattr(recorder, "silence_timed_out", False):
+    did_crash = getattr(recorder, "crashed", False)
+
+    if did_crash:
+        mins, secs = divmod(int(elapsed), 60)
+        click.echo(
+            f"\n\n  Recording process crashed at {mins:02d}:{secs:02d} "
+            f"(exit code: {getattr(recorder, 'exit_code', None)})",
+            err=True,
+        )
+        _log_crash(out_dir, getattr(recorder, "exit_code", None),
+                   getattr(recorder, "stderr_output", ""), elapsed)
+    elif getattr(recorder, "silence_timed_out", False):
         click.echo("\n\nRecording auto-stopped after silence timeout.")
     else:
         click.echo("\n\nStopping recording...")
@@ -244,7 +271,10 @@ def run_pipeline(config: Config) -> None:
         )
         raise SystemExit(1)
 
-    click.echo(f"Audio saved to {audio_path}\n")
+    if did_crash:
+        click.echo(f"Audio recovered to {audio_path}\n")
+    else:
+        click.echo(f"Audio saved to {audio_path}\n")
 
     # Check for silent audio before spending time on transcription
     # Skip if the recorder already reported a silence warning (CoreAudio helper)

--- a/swift/Sources/AudioCapture.swift
+++ b/swift/Sources/AudioCapture.swift
@@ -217,6 +217,12 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
     private var lastLoudTimeLock = os_unfair_lock_s()
     private var silenceTimer: DispatchSourceTimer?
 
+    // Watchdog: detect if SCStream stops delivering callbacks silently
+    private var lastCallbackTime: UInt64 = 0
+    private var lastCallbackTimeLock = os_unfair_lock_s()
+    private var watchdogTimer: DispatchSourceTimer?
+    private let watchdogDeadline: TimeInterval = 10
+
     // Picker continuation
     private var startContinuation: CheckedContinuation<Void, Error>?
 
@@ -297,10 +303,32 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
             lastLoudTime = DispatchTime.now().uptimeNanoseconds
         }
 
+        lastCallbackTime = DispatchTime.now().uptimeNanoseconds
+
         try await stream.startCapture()
         self.stream = stream
 
         fputs("Recording system audio to \(outputPath)... Press Ctrl+C to stop.\n", stderr)
+
+        // Watchdog: detect if SCStream silently stops delivering audio callbacks
+        let wd = DispatchSource.makeTimerSource(queue: .main)
+        wd.schedule(deadline: .now() + 5, repeating: 5.0)
+        wd.setEventHandler { [weak self] in
+            guard let self else { return }
+            let now = DispatchTime.now().uptimeNanoseconds
+            os_unfair_lock_lock(&self.lastCallbackTimeLock)
+            let lastCb = self.lastCallbackTime
+            os_unfair_lock_unlock(&self.lastCallbackTimeLock)
+            guard now >= lastCb else { return }
+            let gap = Double(now - lastCb) / 1_000_000_000.0
+            if gap > self.watchdogDeadline {
+                self.watchdogTimer?.cancel()
+                self.watchdogTimer = nil
+                self.onStreamError?(CaptureError.streamStalled(seconds: gap))
+            }
+        }
+        wd.resume()
+        watchdogTimer = wd
 
         // Start silence timeout timer if configured.
         // Checks every 1s whether both system audio and mic (if active) have been
@@ -342,7 +370,10 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
         guard let audioFile else { return }
         guard CMSampleBufferGetNumSamples(sampleBuffer) > 0 else { return }
 
-        // Capture start host time from first audio buffer
+        os_unfair_lock_lock(&lastCallbackTimeLock)
+        lastCallbackTime = DispatchTime.now().uptimeNanoseconds
+        os_unfair_lock_unlock(&lastCallbackTimeLock)
+
         if startHostTime == 0 {
             startHostTime = mach_absolute_time()
         }
@@ -418,8 +449,11 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
 
     // MARK: - SCStreamDelegate
 
+    var onStreamError: ((Error) -> Void)?
+
     func stream(_ stream: SCStream, didStopWithError error: Error) {
-        fputs("Stream error: \(error)\n", stderr)
+        fputs("[STREAM_ERROR] \(error)\n", stderr)
+        onStreamError?(error)
     }
 
     // MARK: - Stop
@@ -427,6 +461,8 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
     func stop() {
         silenceTimer?.cancel()
         silenceTimer = nil
+        watchdogTimer?.cancel()
+        watchdogTimer = nil
 
         let sem = DispatchSemaphore(value: 0)
         Task.detached { [stream] in
@@ -448,11 +484,13 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
     enum CaptureError: Error, CustomStringConvertible {
         case cannotOpenFile(String)
         case noDisplay
+        case streamStalled(seconds: Double)
 
         var description: String {
             switch self {
             case .cannotOpenFile(let p): return "Cannot open file: \(p)"
             case .noDisplay: return "No display found"
+            case .streamStalled(let s): return "No audio callbacks for \(String(format: "%.0f", s))s"
             }
         }
     }
@@ -828,8 +866,7 @@ func main() {
             capture.micCapture = mic
         }
 
-        // Shared shutdown logic for SIGINT, SIGTERM, and silence timeout
-        let shutdown: () -> Void = {
+        let shutdown: (Int32) -> Void = { exitCode in
             capture.stop()
             if let mic = micCapture {
                 mic.stop()
@@ -844,10 +881,14 @@ func main() {
                     fputs("Error merging audio: \(error)\n", stderr)
                 }
             }
-            exit(0)
+            exit(exitCode)
         }
 
-        capture.onSilenceTimeout = shutdown
+        capture.onSilenceTimeout = { shutdown(0) }
+        capture.onStreamError = { error in
+            fputs("[STREAM_DIED] \(error)\n", stderr)
+            shutdown(2)
+        }
 
         // Toggle mic mute on SIGUSR1 (sent by Python wrapper)
         var _sigusr1Source: DispatchSourceSignal?  // retained to keep source alive
@@ -863,12 +904,12 @@ func main() {
         // Handle Ctrl+C gracefully
         let sigintSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
         signal(SIGINT, SIG_IGN)
-        sigintSource.setEventHandler { shutdown() }
+        sigintSource.setEventHandler { shutdown(0) }
         sigintSource.resume()
 
         let sigtermSource = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
         signal(SIGTERM, SIG_IGN)
-        sigtermSource.setEventHandler { shutdown() }
+        sigtermSource.setEventHandler { shutdown(0) }
         sigtermSource.resume()
 
         Task {


### PR DESCRIPTION
## WIP

## Problem

When `ownscribe-audio` crashes mid-recording (or ScreenCaptureKit silently stops delivering callbacks), the recording is lost. The user sees "No audio was captured" — the actual audio data is sitting in orphaned `.tmp.wav` files that nobody recovers.

ScreenCaptureKit is known to silently stop delivering audio callbacks without triggering `didStopWithError` (documented by OBS and Apple Developer Forums). When this happens, the recording timer keeps counting but no audio is being written — the user doesn't notice until they stop and get a truncated recording.

## Fix

**Swift — detect and handle stream failures:**
- `didStopWithError` now triggers `onStreamError` callback → proper shutdown with audio merge
- Watchdog timer fires every 5s, triggers stream error if no audio callbacks for 10s
- Shutdown closure takes exit code: 0 for normal, 2 for stream error
- New `CaptureError.streamStalled` error case for watchdog failures

**Python — crash recovery:**
- Detect crash via exit code and stderr markers (`[STREAM_ERROR]`, `[STREAM_DIED]`)
- Auto-recover audio from orphaned `.tmp.wav` files via ffmpeg merge
- Write `crash.log` with timestamp, exit code, and full stderr
- User sees "Recording process crashed at MM:SS" instead of "No audio was captured"
- Named constants for stderr markers, centralized parsing in `_finalize_stderr()`

## Test plan

- [x] Normal recording works unchanged (43-minute test)
- [x] Stream error triggers proper shutdown, merge, and non-zero exit
- [x] Python detects crash and recovers audio from tmp files
- [x] Clear error message shown on crash, crash.log written
- [ ] Kill `ownscribe-audio` mid-recording — verify Python recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)