### PR TITLE
Fix llama-cpp cleanup error on exit

### DIFF
--- a/src/ownscribe/summarization/llama_cpp_summarizer.py
+++ b/src/ownscribe/summarization/llama_cpp_summarizer.py
@@ -108,6 +108,14 @@ class LlamaCppSummarizer(Summarizer):
         self._templates = templates or {}
         self._llm: Llama | None = None
 
+    def __del__(self) -> None:
+        """Ensure the model is properly closed on cleanup."""
+        if self._llm is not None:
+            try:
+                self._llm.close()
+            except Exception:
+                pass
+
     def _get_llm(self) -> Llama:
         """Lazy-load the model on first use."""
         if self._llm is not None:

--- a/src/ownscribe/summarization/llama_cpp_summarizer.py
+++ b/src/ownscribe/summarization/llama_cpp_summarizer.py
@@ -110,11 +110,10 @@ class LlamaCppSummarizer(Summarizer):
 
     def __del__(self) -> None:
         """Ensure the model is properly closed on cleanup."""
-        if self._llm is not None:
-            try:
-                self._llm.close()
-            except Exception:
-                pass
+        llm = getattr(self, "_llm", None)
+        if llm is not None:
+            with contextlib.suppress(Exception):
+                llm.close()
 
     def _get_llm(self) -> Llama:
         """Lazy-load the model on first use."""


### PR DESCRIPTION
Add __del__ method to LlamaCppSummarizer to explicitly close the Llama model before garbage collection, preventing TypeError during cleanup.