### PR TITLE
Add initial_prompt and hotwords support for Whisper transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ silence_timeout = 300     # seconds of silence before auto-stop; 0 = disabled
 [transcription]
 model = "base"            # tiny, base, small, medium, large-v3
 language = ""             # empty = auto-detect
+# initial_prompt = ""     # prime Whisper with context: domain vocab, speaker names, expected phrases
+# hotwords = ""           # comma-separated words to boost recognition (softer hint than initial_prompt)
 
 [diarization]
 enabled = false

--- a/src/ownscribe/cli.py
+++ b/src/ownscribe/cli.py
@@ -37,7 +37,7 @@ def _dir_size(path: str) -> str:
 @click.option("--format", "output_format", type=click.Choice(["markdown", "json"]), default=None, help="Output format.")
 @click.option("--model", default=None, help="Whisper model size (tiny, base, small, medium, large-v3).")
 @click.option("--language", default=None, help="Language code for transcription (e.g. en, de, fr).")
-@click.option("--initial-prompt", default=None, help="Context text to prime Whisper (domain vocab, speaker names, etc.).")
+@click.option("--initial-prompt", default=None, help="Context text to prime Whisper (vocab, speaker names, etc.)")
 @click.option("--hotwords", default=None, help="Comma-separated words to boost Whisper recognition.")
 @click.option("--mic", is_flag=True, help="Also capture microphone input (mixed with system audio).")
 @click.option("--mic-device", default=None, help="Specific mic device name (implies --mic).")

--- a/src/ownscribe/cli.py
+++ b/src/ownscribe/cli.py
@@ -37,6 +37,8 @@ def _dir_size(path: str) -> str:
 @click.option("--format", "output_format", type=click.Choice(["markdown", "json"]), default=None, help="Output format.")
 @click.option("--model", default=None, help="Whisper model size (tiny, base, small, medium, large-v3).")
 @click.option("--language", default=None, help="Language code for transcription (e.g. en, de, fr).")
+@click.option("--initial-prompt", default=None, help="Context text to prime Whisper (domain vocab, speaker names, etc.).")
+@click.option("--hotwords", default=None, help="Comma-separated words to boost Whisper recognition.")
 @click.option("--mic", is_flag=True, help="Also capture microphone input (mixed with system audio).")
 @click.option("--mic-device", default=None, help="Specific mic device name (implies --mic).")
 @click.option(
@@ -58,6 +60,8 @@ def cli(
     output_format: str | None,
     model: str | None,
     language: str | None,
+    initial_prompt: str | None,
+    hotwords: str | None,
     mic: bool,
     mic_device: str | None,
     keep_recording: bool | None,
@@ -86,6 +90,10 @@ def cli(
         config.transcription.model = model
     if language:
         config.transcription.language = language
+    if initial_prompt:
+        config.transcription.initial_prompt = initial_prompt
+    if hotwords:
+        config.transcription.hotwords = hotwords
     if mic or mic_device:
         config.audio.mic = True
     if mic_device:

--- a/src/ownscribe/config.py
+++ b/src/ownscribe/config.py
@@ -21,6 +21,8 @@ silence_timeout = 300     # seconds of silence before auto-stop; 0 = disabled
 [transcription]
 model = "base"            # whisper model: tiny, base, small, medium, large-v3
 language = ""             # empty = auto-detect
+# initial_prompt = ""     # prime Whisper with context: domain vocab, speaker names, expected phrases
+# hotwords = ""           # comma-separated words to boost recognition (softer hint than initial_prompt)
 
 [diarization]
 enabled = false           # set to true + provide hf_token to enable
@@ -63,6 +65,8 @@ class AudioConfig:
 class TranscriptionConfig:
     model: str = "base"
     language: str = ""
+    initial_prompt: str = ""
+    hotwords: str = ""
 
 
 @dataclass

--- a/src/ownscribe/transcription/whisperx_transcriber.py
+++ b/src/ownscribe/transcription/whisperx_transcriber.py
@@ -46,11 +46,17 @@ class WhisperXTranscriber(Transcriber):
 
         device = "cpu"
         compute_type = "int8"
+        asr_options = {}
+        if self._tx_config.initial_prompt:
+            asr_options["initial_prompt"] = self._tx_config.initial_prompt
+        if self._tx_config.hotwords:
+            asr_options["hotwords"] = self._tx_config.hotwords
         self._model = whisperx.load_model(
             self._tx_config.model,
             device,
             compute_type=compute_type,
             language=self._tx_config.language or None,
+            asr_options=asr_options or None,
         )
 
     def _configure_runtime_env(self) -> None:


### PR DESCRIPTION
## Problem
WhisperX exposes `initial_prompt` (context priming) and `hotwords` (recognition
boosts for specific terms) via `asr_options`, but ownscribe had no way to pass
them through. Without them, recordings with product names, jargon, or non-English
proper nouns get silently mis-transcribed with no fix short of post-processing.

## Solution

Expose both parameters via:
- CLI flags: `--initial-prompt` and `--hotwords`
- Config file: `initial_prompt` and `hotwords` under `[transcription]`

Both default to empty (no change to existing behaviour). When set, they are forwarded
to `whisperx.load_model()` via `asr_options`.

# One-off via CLI
ownscribe --initial-prompt "Acme Corp Q2 planning. Speakers: Alice, Bob." \
          --hotwords "ownscribe,WhisperX,pyannote"

# Persistent via config
[transcription]
initial_prompt = "Weekly eng sync. Speakers: Alice, Bob, Carol."
hotwords = "ownscribe,WhisperX,pyannote"

## Test plan

- [x] `uv run pytest` — all 230 tests pass
- [x] `uv run ruff check src/ tests/` — clean
- [x] `--initial-prompt` and `--hotwords` appear in `ownscribe --help`
- [x] Setting both in config and running a transcription forwards them to WhisperX
      without error
- [x] Omitting both leaves existing behaviour unchanged (`asr_options` stays empty)