### PR TITLE
Prevent display sleep from killing SCStream during recording

### DIFF
--- a/swift/Sources/AudioCapture.swift
+++ b/swift/Sources/AudioCapture.swift
@@ -6,6 +6,7 @@ import Foundation
 import AppKit
 import CoreAudio
 import AudioToolbox
+import IOKit.pwr_mgt
 
 // MARK: - Constants
 
@@ -217,6 +218,9 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
     private var lastLoudTimeLock = os_unfair_lock_s()
     private var silenceTimer: DispatchSourceTimer?
 
+    // Power assertion to prevent display sleep during capture
+    private var powerAssertionID: IOPMAssertionID = IOPMAssertionID(kIOPMNullAssertionID)
+
     // Picker continuation
     private var startContinuation: CheckedContinuation<Void, Error>?
 
@@ -299,6 +303,12 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
 
         try await stream.startCapture()
         self.stream = stream
+
+        IOPMAssertionCreateWithName(
+            kIOPMAssertionTypePreventUserIdleDisplaySleep as CFString,
+            IOPMAssertionLevel(kIOPMAssertionLevelOn),
+            "ownscribe is recording audio" as CFString,
+            &powerAssertionID)
 
         fputs("Recording system audio to \(outputPath)... Press Ctrl+C to stop.\n", stderr)
 
@@ -427,6 +437,11 @@ class SystemAudioCapture: NSObject, SCStreamOutput, SCStreamDelegate, SCContentS
     func stop() {
         silenceTimer?.cancel()
         silenceTimer = nil
+
+        if powerAssertionID != IOPMAssertionID(kIOPMNullAssertionID) {
+            IOPMAssertionRelease(powerAssertionID)
+            powerAssertionID = IOPMAssertionID(kIOPMNullAssertionID)
+        }
 
         let sem = DispatchSemaphore(value: 0)
         Task.detached { [stream] in


### PR DESCRIPTION
## Summary

- Hold an `IOPMAssertion` (`PreventUserIdleDisplaySleep`) while the ScreenCaptureKit stream is active
- Releases the assertion on stop, and auto-releases if the process crashes

## Problem

macOS tears down `SCStream` with error `-3821` ("Stream was stopped by the system") when the display idles to sleep. This is especially aggressive on battery power — recordings can be killed after just a few minutes of no keyboard/trackpad input, even while the meeting is still happening.

## Fix

Same approach used by OBS, QuickTime, and Zoom: create a power assertion when capture starts, release it when capture stops. This tells macOS "someone is actively using this capture session, don't idle-sleep the display."

The assertion is scoped to the process lifetime — if `ownscribe-audio` crashes or is killed, macOS automatically releases it.

## Test plan

- [ ] Start a recording on battery, leave the computer idle for 5+ minutes — recording should survive
- [ ] Verify assertion appears in `pmset -g assertions` during recording
- [ ] Verify assertion disappears after Ctrl+C stop
- [ ] Verify normal display sleep resumes after recording ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)