### PR TITLE
Build Swift binary on release published, not created

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -2,7 +2,7 @@ name: Build Swift Binary
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem

`build-binary.yml` triggers on `release: [created]`. GitHub does **not** fire the `created` event when a release is published from a previously-saved **draft** — it only fires for releases "published without previously being saved as a draft."

As a result, the binary build was silently skipped for v0.12.0 (created as a draft, then published), while `publish.yml` (which listens on `published`) still ran and pushed to PyPI. The `ownscribe-audio-arm64` asset was missing, so `releases/latest/download/...` 404'd for fresh installs.

## Fix

Switch the trigger to `published`, which fires for **both** draft→publish and direct-publish flows. This makes the safer draft-first release ordering work correctly.

## Notes

- v0.12.0 has already had the binary uploaded manually as a one-off recovery.
- Follow-up worth considering: add `workflow_dispatch` so the binary can be rebuilt without a new release, and build an `x86_64` asset (the download URL supports it, but only `arm64` is ever published).