### PR TITLE
fix: free local llama-cpp model deterministically to prevent crash on exit

### DIFF
--- a/src/ownscribe/pipeline.py
+++ b/src/ownscribe/pipeline.py
@@ -346,33 +346,36 @@ def run_summarize(config: Config, transcript_file: str) -> None:
     out_dir = transcript_path.parent
     local_sum = config.summarization.backend == "local"
 
-    with PipelineProgress(
-        transcribe=False,
-        diarize=False,
-        summarize=True,
-        download_summarizer=local_sum,
-    ) as progress:
-        progress.begin("summarizing")
-        if local_sum:
-            progress.begin("downloading_model")
-            try:
-                _download_summarization_model(
-                    config.summarization.model,
-                    progress,
-                    "downloading_model",
-                )
-                progress.complete("downloading_model")
-            except Exception:
-                progress.fail("downloading_model")
-                click.echo(
-                    f"Error: Failed to download summarization model '{config.summarization.model}'.\n"
-                    "Check your internet connection and try again.",
-                    err=True,
-                )
-                raise SystemExit(1) from None
-        summary = summarizer.summarize(transcript_text)
-        title_slug = _generate_title_slug(summary, summarizer)
-        progress.complete("summarizing")
+    try:
+        with PipelineProgress(
+            transcribe=False,
+            diarize=False,
+            summarize=True,
+            download_summarizer=local_sum,
+        ) as progress:
+            progress.begin("summarizing")
+            if local_sum:
+                progress.begin("downloading_model")
+                try:
+                    _download_summarization_model(
+                        config.summarization.model,
+                        progress,
+                        "downloading_model",
+                    )
+                    progress.complete("downloading_model")
+                except Exception:
+                    progress.fail("downloading_model")
+                    click.echo(
+                        f"Error: Failed to download summarization model '{config.summarization.model}'.\n"
+                        "Check your internet connection and try again.",
+                        err=True,
+                    )
+                    raise SystemExit(1) from None
+            summary = summarizer.summarize(transcript_text)
+            title_slug = _generate_title_slug(summary, summarizer)
+            progress.complete("summarizing")
+    finally:
+        summarizer.close()
 
     summary_md = format_summary(summary)
     summary_path = out_dir / "summary.md"
@@ -438,28 +441,31 @@ def _do_transcribe_and_summarize(
             except ImportError as exc:
                 click.echo(f"Error: {exc}", err=True)
                 raise SystemExit(1) from None
-            if not summarizer.is_available():
-                sum_unavailable = True
-            else:
-                try:
-                    progress.begin("summarizing")
-                    if local_sum:
-                        progress.begin("downloading_model")
-                        _download_summarization_model(
-                            config.summarization.model,
-                            progress,
-                            "downloading_model",
-                        )
-                        progress.complete("downloading_model")
-                    summary = summarizer.summarize(result.full_text)
-                    _, summary_str = _format_output(config, result, summary)
-                    summary_path = out_dir / f"summary.{ext}"
-                    summary_path.write_text(summary_str or summary)
-                    title_slug = _generate_title_slug(summary, summarizer)
-                    progress.complete("summarizing")
-                except Exception:
-                    progress.fail("summarizing")
-                    sum_failed = True
+            try:
+                if not summarizer.is_available():
+                    sum_unavailable = True
+                else:
+                    try:
+                        progress.begin("summarizing")
+                        if local_sum:
+                            progress.begin("downloading_model")
+                            _download_summarization_model(
+                                config.summarization.model,
+                                progress,
+                                "downloading_model",
+                            )
+                            progress.complete("downloading_model")
+                        summary = summarizer.summarize(result.full_text)
+                        _, summary_str = _format_output(config, result, summary)
+                        summary_path = out_dir / f"summary.{ext}"
+                        summary_path.write_text(summary_str or summary)
+                        title_slug = _generate_title_slug(summary, summarizer)
+                        progress.complete("summarizing")
+                    except Exception:
+                        progress.fail("summarizing")
+                        sum_failed = True
+            finally:
+                summarizer.close()
 
     # --- All user-facing output after TUI exits ---
     click.echo(f"Transcript saved to {transcript_path}")

--- a/src/ownscribe/search.py
+++ b/src/ownscribe/search.py
@@ -63,37 +63,38 @@ def ask(config: Config, question: str, since: str | None, limit: int | None) -> 
     except ImportError as exc:
         click.echo(f"Error: {exc}", err=True)
         return
-    if not summarizer.is_available():
-        click.echo("Summarization backend is not reachable. Check your configuration.")
-        return
+    with summarizer:
+        if not summarizer.is_available():
+            click.echo("Summarization backend is not reachable. Check your configuration.")
+            return
 
-    context_size = _resolve_context_size(config)
+        context_size = _resolve_context_size(config)
 
-    # Stage 1
-    label = f"Searching {len(meetings)} meetings"
-    with Spinner(label) as spinner:
-        relevant = _find_relevant_meetings(
-            summarizer, question, meetings, context_size, spinner=spinner,
-        )
-        spinner.update(label)  # restore label so exit message is clean
+        # Stage 1
+        label = f"Searching {len(meetings)} meetings"
+        with Spinner(label) as spinner:
+            relevant = _find_relevant_meetings(
+                summarizer, question, meetings, context_size, spinner=spinner,
+            )
+            spinner.update(label)  # restore label so exit message is clean
 
-    if not relevant:
-        click.echo("No relevant meetings found for your question.")
-        return
+        if not relevant:
+            click.echo("No relevant meetings found for your question.")
+            return
 
-    click.echo(f"Found {len(relevant)} relevant meetings:")
-    for m in relevant:
-        click.echo(f"  - {m.display_name}")
+        click.echo(f"Found {len(relevant)} relevant meetings:")
+        for m in relevant:
+            click.echo(f"  - {m.display_name}")
 
-    # Stage 2
-    with Spinner("Analyzing transcripts"):
-        answer, skipped_transcripts = _answer_from_transcripts(summarizer, question, relevant, context_size)
-        answer = _verify_quotes(answer, _load_transcripts(relevant))
+        # Stage 2
+        with Spinner("Analyzing transcripts"):
+            answer, skipped_transcripts = _answer_from_transcripts(summarizer, question, relevant, context_size)
+            answer = _verify_quotes(answer, _load_transcripts(relevant))
 
-    if skipped_transcripts:
-        click.echo(f"({skipped_transcripts} transcripts did not fit within context budget, they were skipped)")
+        if skipped_transcripts:
+            click.echo(f"({skipped_transcripts} transcripts did not fit within context budget, they were skipped)")
 
-    click.echo(answer)
+        click.echo(answer)
 
 
 

--- a/src/ownscribe/summarization/base.py
+++ b/src/ownscribe/summarization/base.py
@@ -26,3 +26,12 @@ class Summarizer(abc.ABC):
     @abc.abstractmethod
     def is_available(self) -> bool:
         """Check if the summarization backend is reachable."""
+
+    def close(self) -> None:  # noqa: B027 — intentional optional hook, not abstract
+        """Release any native resources. No-op by default; must be idempotent."""
+
+    def __enter__(self) -> Summarizer:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()

--- a/src/ownscribe/summarization/llama_cpp_summarizer.py
+++ b/src/ownscribe/summarization/llama_cpp_summarizer.py
@@ -108,12 +108,23 @@ class LlamaCppSummarizer(Summarizer):
         self._templates = templates or {}
         self._llm: Llama | None = None
 
-    def __del__(self) -> None:
-        """Ensure the model is properly closed on cleanup."""
-        llm = getattr(self, "_llm", None)
+    def close(self) -> None:
+        """Free the loaded model deterministically. Idempotent."""
+        llm = self._llm
+        self._llm = None
         if llm is not None:
-            with contextlib.suppress(Exception):
+            # Plain try/except, not contextlib.suppress: this runs from __del__ at
+            # interpreter shutdown when the `contextlib` global is already None.
+            try:  # noqa: SIM105
                 llm.close()
+            except Exception:
+                pass
+
+    def __del__(self) -> None:
+        try:  # noqa: SIM105
+            self.close()
+        except Exception:
+            pass
 
     def _get_llm(self) -> Llama:
         """Lazy-load the model on first use."""

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -639,6 +639,80 @@ class TestLlamaCppTemplatePassthrough:
         assert "Key Concepts" in call_args[1]["messages"][1]["content"]
 
 
+class TestLlamaCppClose:
+    """Test deterministic cleanup of the local model."""
+
+    def test_close_frees_loaded_model(self, mock_llama):
+        config = SummarizationConfig(backend="local", model="phi-4-mini")
+
+        from ownscribe.summarization.llama_cpp_summarizer import LlamaCppSummarizer
+
+        summarizer = LlamaCppSummarizer(config)
+        summarizer._get_llm()
+        summarizer.close()
+
+        mock_llama.close.assert_called_once()
+        assert summarizer._llm is None
+
+    def test_close_is_idempotent(self, mock_llama):
+        config = SummarizationConfig(backend="local", model="phi-4-mini")
+
+        from ownscribe.summarization.llama_cpp_summarizer import LlamaCppSummarizer
+
+        summarizer = LlamaCppSummarizer(config)
+        summarizer._get_llm()
+        summarizer.close()
+        summarizer.close()
+
+        mock_llama.close.assert_called_once()
+
+    def test_close_without_load_is_noop(self, mock_llama):
+        config = SummarizationConfig(backend="local", model="phi-4-mini")
+
+        from ownscribe.summarization.llama_cpp_summarizer import LlamaCppSummarizer
+
+        summarizer = LlamaCppSummarizer(config)
+        summarizer.close()
+
+        mock_llama.close.assert_not_called()
+
+    def test_close_suppresses_errors(self, mock_llama):
+        mock_llama.close.side_effect = RuntimeError("boom")
+        config = SummarizationConfig(backend="local", model="phi-4-mini")
+
+        from ownscribe.summarization.llama_cpp_summarizer import LlamaCppSummarizer
+
+        summarizer = LlamaCppSummarizer(config)
+        summarizer._get_llm()
+        summarizer.close()
+
+        assert summarizer._llm is None
+
+    def test_context_manager_closes_model(self, mock_llama):
+        config = SummarizationConfig(backend="local", model="phi-4-mini")
+
+        from ownscribe.summarization.llama_cpp_summarizer import LlamaCppSummarizer
+
+        with LlamaCppSummarizer(config) as summarizer:
+            assert summarizer._get_llm() is mock_llama
+
+        mock_llama.close.assert_called_once()
+
+
+class TestSummarizerCloseContract:
+    """Backends without native resources inherit a no-op close + context manager."""
+
+    def test_ollama_close_is_noop_and_context_manager(self):
+        config = SummarizationConfig(host="http://localhost:1", backend="ollama", model="x")
+
+        from ownscribe.summarization.ollama_summarizer import OllamaSummarizer
+
+        summarizer = OllamaSummarizer(config)
+        with summarizer as entered:
+            assert entered is summarizer
+        summarizer.close()
+
+
 class TestEnsureModel:
     """Test _ensure_model with various model specifications."""
 


### PR DESCRIPTION
## Problem

Running `ownscribe` with the local (`llama-cpp`) summarization backend crashes on exit, after the summary has already been produced and saved:

```
Exception ignored in: <function LlamaCppSummarizer.__del__ ...>
AttributeError: 'NoneType' object has no attribute 'suppress'
Exception ignored in: <function Llama.__del__ ...>
TypeError: 'NoneType' object is not callable
ggml-metal-device.m:622: GGML_ASSERT([rsets->data count] == 0) failed
fish: Job 1, 'ownscribe' terminated by signal SIGABRT (Abort)
```

## Root cause

The loaded `Llama` model was only ever released via `__del__`. The summarizer object survives until interpreter shutdown, at which point module globals are torn down to `None`:

- `LlamaCppSummarizer.__del__` calls `contextlib.suppress(...)`, but the module-level `contextlib` is already `None` → `AttributeError`.
- `llama_cpp`'s own `Llama.__del__` calls `free_model`, but its C-function pointer is already `None` → `TypeError`.

Because `free_model` never runs, the Metal buffers stay allocated. When the process finally reaches `exit()` → `__cxa_finalize` → `ggml_metal_device_free`, the global device still has live residency sets, so `GGML_ASSERT([rsets->data count] == 0)` aborts the process with `SIGABRT`.

`__del__` is fundamentally the wrong place for this — at shutdown the model *cannot* be freed because llama_cpp's C bindings are already gone.

## Fix

Free the model **deterministically while the interpreter is still alive**, instead of relying on `__del__`:

- Add an idempotent `close()` plus context-manager protocol (`__enter__`/`__exit__`) to the `Summarizer` base contract (no-op default; backends without native resources inherit it for free).
- Implement `close()` in `LlamaCppSummarizer` to free `self._llm`. It uses a plain `try/except` rather than `contextlib.suppress` precisely because it may also run from `__del__` at shutdown when `contextlib` is `None`.
- Call `close()` deterministically from every summarization path: `run_summarize` and `_do_transcribe_and_summarize` (via `try/finally`) in `pipeline.py`, and `ask` (via `with summarizer:`) in `search.py`.
- `__del__` remains only as a best-effort backstop.

## Testing

- Added 6 unit tests covering `close()` (frees model, idempotent, no-op without load, error suppression, context manager) and the inherited no-op contract for non-local backends.
- Full suite: **237 passed**; `ruff check src/ tests/` passes.
- End-to-end: ran `ownscribe summarize` on a real transcript with the cached `phi-4-mini` model → **exit code 0, none** of the `Exception ignored` / `GGML_ASSERT` / `SIGABRT` markers.
