### PR TITLE
feat: dedicated output dir for transcribe/summarize + --summarize flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ swift/.build/
 
 # asciinema recordings (regenerated from scripts/)
 *.cast
+
+node_modules

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ ownscribe devices                  # list audio devices (uses native CoreAudio w
 ownscribe apps                     # list running apps with PIDs for use with --pid
 ownscribe warmup                   # prefetch WhisperX/pyannote models before a meeting
 ownscribe transcribe recording.wav # transcribe an audio file (copies it into a new output dir)
+ownscribe transcribe recording.wav --summarize # transcribe, then also summarize
 ownscribe summarize transcript.md  # summarize a transcript (copies it into a new output dir)
 ownscribe resume ./2026-02-20_1736 # resume a failed/partial pipeline in a directory
 ownscribe ask "question"           # search your meetings with a natural-language question

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ Works with any app that outputs audio through Core Audio (Zoom, Teams, Meet, etc
 
 > **Tip:** Your terminal app (Terminal, iTerm2, VS Code, etc.) needs **Screen Recording** permission to capture system audio.
 > Open the settings panel directly with:
+>
 > ```bash
 > open "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
 > ```
+>
 > Enable your terminal app, then restart it.
 
 ## Installation
@@ -115,6 +117,7 @@ ownscribe                    # records system audio, Ctrl+C to stop
 ```
 
 This will:
+
 1. Capture system audio until you press Ctrl+C (or auto-stop after 5 minutes of silence)
 2. Transcribe with WhisperX
 3. Summarize with your local LLM
@@ -147,8 +150,8 @@ ownscribe --silence-timeout 0                 # disable silence auto-stop
 ownscribe devices                  # list audio devices (uses native CoreAudio when available)
 ownscribe apps                     # list running apps with PIDs for use with --pid
 ownscribe warmup                   # prefetch WhisperX/pyannote models before a meeting
-ownscribe transcribe recording.wav # transcribe an audio file (saves alongside the input)
-ownscribe summarize transcript.md  # summarize a transcript (saves alongside the input)
+ownscribe transcribe recording.wav # transcribe an audio file (copies it into a new output dir)
+ownscribe summarize transcript.md  # summarize a transcript (copies it into a new output dir)
 ownscribe resume ./2026-02-20_1736 # resume a failed/partial pipeline in a directory
 ownscribe ask "question"           # search your meetings with a natural-language question
 ownscribe config                   # open config file in $EDITOR
@@ -174,6 +177,7 @@ ownscribe ask "action items from last week" --limit 5
 ```
 
 This runs a two-stage pipeline:
+
 1. **Find** — sends meeting summaries to the LLM to identify which meetings are relevant
 2. **Answer** — sends the full transcripts of relevant meetings to the LLM to produce an answer with quotes
 
@@ -252,7 +256,7 @@ Then use with `--template my-standup` or `template = "my-standup"` in config.
 Speaker identification requires a HuggingFace token with access to the pyannote diarization model:
 
 1. Accept the terms for [pyannote/speaker-diarization-community-1](https://huggingface.co/pyannote/speaker-diarization-community-1) on HuggingFace
-2. Create a token at https://huggingface.co/settings/tokens
+2. Create a token at <https://huggingface.co/settings/tokens>
 3. Set `HF_TOKEN` env var or add `hf_token` to config
 4. Run with `--diarize`
 

--- a/src/ownscribe/cli.py
+++ b/src/ownscribe/cli.py
@@ -141,18 +141,21 @@ def devices() -> None:
 @cli.command()
 @click.argument("file", type=click.Path(exists=True))
 @click.option("--diarize", is_flag=True, help="Enable speaker diarization.")
+@click.option("--summarize", is_flag=True, help="Also summarize after transcribing.")
 @click.option("--model", default=None, help="Whisper model size.")
 @click.option("--language", default=None, help="Language code for transcription (e.g. en, de, fr).")
 @click.option("--format", "output_format", type=click.Choice(["markdown", "json"]), default=None)
 @click.pass_context
 def transcribe(
-    ctx: click.Context, file: str, diarize: bool,
+    ctx: click.Context, file: str, diarize: bool, summarize: bool,
     model: str | None, language: str | None, output_format: str | None,
 ) -> None:
     """Transcribe an audio file."""
     config = ctx.obj["config"]
     if diarize:
         config.diarization.enabled = True
+    if summarize:
+        config.summarization.enabled = True
     if model:
         config.transcription.model = model
     if language:
@@ -161,7 +164,7 @@ def transcribe(
         config.output.format = output_format
 
     from ownscribe.pipeline import run_transcribe
-    run_transcribe(config, file)
+    run_transcribe(config, file, summarize=summarize)
 
 
 @cli.command()

--- a/src/ownscribe/pipeline.py
+++ b/src/ownscribe/pipeline.py
@@ -346,33 +346,36 @@ def run_summarize(config: Config, transcript_file: str) -> None:
     out_dir = transcript_path.parent
     local_sum = config.summarization.backend == "local"
 
-    with PipelineProgress(
-        transcribe=False,
-        diarize=False,
-        summarize=True,
-        download_summarizer=local_sum,
-    ) as progress:
-        progress.begin("summarizing")
-        if local_sum:
-            progress.begin("downloading_model")
-            try:
-                _download_summarization_model(
-                    config.summarization.model,
-                    progress,
-                    "downloading_model",
-                )
-                progress.complete("downloading_model")
-            except Exception:
-                progress.fail("downloading_model")
-                click.echo(
-                    f"Error: Failed to download summarization model '{config.summarization.model}'.\n"
-                    "Check your internet connection and try again.",
-                    err=True,
-                )
-                raise SystemExit(1) from None
-        summary = summarizer.summarize(transcript_text)
-        title_slug = _generate_title_slug(summary, summarizer)
-        progress.complete("summarizing")
+    try:
+        with PipelineProgress(
+            transcribe=False,
+            diarize=False,
+            summarize=True,
+            download_summarizer=local_sum,
+        ) as progress:
+            progress.begin("summarizing")
+            if local_sum:
+                progress.begin("downloading_model")
+                try:
+                    _download_summarization_model(
+                        config.summarization.model,
+                        progress,
+                        "downloading_model",
+                    )
+                    progress.complete("downloading_model")
+                except Exception:
+                    progress.fail("downloading_model")
+                    click.echo(
+                        f"Error: Failed to download summarization model '{config.summarization.model}'.\n"
+                        "Check your internet connection and try again.",
+                        err=True,
+                    )
+                    raise SystemExit(1) from None
+            summary = summarizer.summarize(transcript_text)
+            title_slug = _generate_title_slug(summary, summarizer)
+            progress.complete("summarizing")
+    finally:
+        summarizer.close()
 
     summary_md = format_summary(summary)
     summary_path = out_dir / "summary.md"
@@ -438,28 +441,31 @@ def _do_transcribe_and_summarize(
             except ImportError as exc:
                 click.echo(f"Error: {exc}", err=True)
                 raise SystemExit(1) from None
-            if not summarizer.is_available():
-                sum_unavailable = True
-            else:
-                try:
-                    progress.begin("summarizing")
-                    if local_sum:
-                        progress.begin("downloading_model")
-                        _download_summarization_model(
-                            config.summarization.model,
-                            progress,
-                            "downloading_model",
-                        )
-                        progress.complete("downloading_model")
-                    summary = summarizer.summarize(result.full_text)
-                    _, summary_str = _format_output(config, result, summary)
-                    summary_path = out_dir / f"summary.{ext}"
-                    summary_path.write_text(summary_str or summary)
-                    title_slug = _generate_title_slug(summary, summarizer)
-                    progress.complete("summarizing")
-                except Exception:
-                    progress.fail("summarizing")
-                    sum_failed = True
+            try:
+                if not summarizer.is_available():
+                    sum_unavailable = True
+                else:
+                    try:
+                        progress.begin("summarizing")
+                        if local_sum:
+                            progress.begin("downloading_model")
+                            _download_summarization_model(
+                                config.summarization.model,
+                                progress,
+                                "downloading_model",
+                            )
+                            progress.complete("downloading_model")
+                        summary = summarizer.summarize(result.full_text)
+                        _, summary_str = _format_output(config, result, summary)
+                        summary_path = out_dir / f"summary.{ext}"
+                        summary_path.write_text(summary_str or summary)
+                        title_slug = _generate_title_slug(summary, summarizer)
+                        progress.complete("summarizing")
+                    except Exception:
+                        progress.fail("summarizing")
+                        sum_failed = True
+            finally:
+                summarizer.close()
 
     # --- All user-facing output after TUI exits ---
     click.echo(f"Transcript saved to {transcript_path}")

--- a/src/ownscribe/pipeline.py
+++ b/src/ownscribe/pipeline.py
@@ -294,7 +294,7 @@ def run_pipeline(config: Config) -> None:
     _do_transcribe_and_summarize(config, audio_path, out_dir)
 
 
-def run_transcribe(config: Config, audio_file: str) -> None:
+def run_transcribe(config: Config, audio_file: str, *, summarize: bool = False) -> None:
     """Transcribe an audio file into a fresh ownscribe output directory."""
     source_path = Path(audio_file).resolve()
     _check_audio_silence(source_path)
@@ -305,7 +305,7 @@ def run_transcribe(config: Config, audio_file: str) -> None:
         out_dir = _get_named_output_dir(config, source_path.stem)
         audio_path = out_dir / f"recording{source_path.suffix}"
         shutil.copy2(source_path, audio_path)
-    _do_transcribe_and_summarize(config, audio_path, out_dir, summarize=False)
+    _do_transcribe_and_summarize(config, audio_path, out_dir, summarize=summarize)
 
 
 def run_warmup(config: Config) -> None:

--- a/src/ownscribe/pipeline.py
+++ b/src/ownscribe/pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import select
+import shutil
 import signal
 import sys
 import termios
@@ -64,6 +65,25 @@ def _get_output_dir(config: Config) -> Path:
     out_dir = base / timestamp
     out_dir.mkdir(parents=True, exist_ok=True)
     return out_dir
+
+
+def _get_named_output_dir(config: Config, name: str) -> Path:
+    """Create a timestamped output directory named after a source file."""
+    base = config.output.resolved_dir
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H%M")
+    slug = _slugify(name) or "file"
+    out_dir = base / f"{timestamp}_{slug}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def _within_output_dir(config: Config, path: Path) -> bool:
+    """True if path already lives inside the configured output directory."""
+    try:
+        path.resolve().relative_to(config.output.resolved_dir.resolve())
+        return True
+    except ValueError:
+        return False
 
 
 def _create_recorder(config: Config):
@@ -149,6 +169,24 @@ def _generate_title_slug(summary: str, summarizer) -> str:
     except Exception:
         logging.getLogger(__name__).warning("Could not generate title", exc_info=True)
         return ""
+
+
+_TIMESTAMP_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2}_\d{4}")
+
+
+def _rename_with_title(out_dir: Path, title_slug: str) -> Path:
+    """Rename out_dir to '<timestamp>_<title_slug>', preserving the timestamp prefix."""
+    match = _TIMESTAMP_PREFIX.match(out_dir.name)
+    prefix = match.group(0) if match else out_dir.name
+    new_dir = out_dir.parent / f"{prefix}_{title_slug}"
+    if new_dir == out_dir:
+        return out_dir
+    try:
+        out_dir.rename(new_dir)
+        return new_dir
+    except Exception:
+        logging.getLogger(__name__).warning("Could not rename output directory", exc_info=True)
+        return out_dir
 
 
 def run_pipeline(config: Config) -> None:
@@ -257,11 +295,16 @@ def run_pipeline(config: Config) -> None:
 
 
 def run_transcribe(config: Config, audio_file: str) -> None:
-    """Transcribe an audio file and save the transcript alongside the input."""
-    audio_path = Path(audio_file).resolve()
-    _check_audio_silence(audio_path)
-    out_dir = audio_path.parent
-    out_dir.mkdir(parents=True, exist_ok=True)
+    """Transcribe an audio file into a fresh ownscribe output directory."""
+    source_path = Path(audio_file).resolve()
+    _check_audio_silence(source_path)
+    if _within_output_dir(config, source_path):
+        out_dir = source_path.parent
+        audio_path = source_path
+    else:
+        out_dir = _get_named_output_dir(config, source_path.stem)
+        audio_path = out_dir / f"recording{source_path.suffix}"
+        shutil.copy2(source_path, audio_path)
     _do_transcribe_and_summarize(config, audio_path, out_dir, summarize=False)
 
 
@@ -317,8 +360,12 @@ def run_warmup(config: Config) -> None:
         click.echo(f"Summarization model ready: {config.summarization.model}")
 
 
-def run_summarize(config: Config, transcript_file: str) -> None:
-    """Summarize a transcript file and save the summary alongside the input."""
+def run_summarize(config: Config, transcript_file: str, *, in_place: bool = False) -> None:
+    """Summarize a transcript file into a fresh ownscribe output directory.
+
+    When ``in_place`` is set, summarize within the transcript's own directory
+    (used by ``resume`` to complete an existing meeting directory).
+    """
     transcript_path = Path(transcript_file).resolve()
     transcript_text = transcript_path.read_text()
 
@@ -343,7 +390,11 @@ def run_summarize(config: Config, transcript_file: str) -> None:
 
     from ownscribe.output.markdown import format_summary
 
-    out_dir = transcript_path.parent
+    if in_place or _within_output_dir(config, transcript_path):
+        out_dir = transcript_path.parent
+    else:
+        out_dir = _get_named_output_dir(config, transcript_path.stem)
+        shutil.copy2(transcript_path, out_dir / f"transcript{transcript_path.suffix}")
     local_sum = config.summarization.backend == "local"
 
     try:
@@ -382,12 +433,7 @@ def run_summarize(config: Config, transcript_file: str) -> None:
     summary_path.write_text(summary_md)
 
     if title_slug:
-        new_dir = out_dir.parent / f"{out_dir.name}_{title_slug}"
-        try:
-            out_dir.rename(new_dir)
-            out_dir = new_dir
-        except Exception:
-            logging.getLogger(__name__).warning("Could not rename output directory", exc_info=True)
+        out_dir = _rename_with_title(out_dir, title_slug)
 
     summary_path = out_dir / "summary.md"
 
@@ -496,12 +542,7 @@ def _do_transcribe_and_summarize(
         click.echo(f"Summary saved to {out_dir / f'summary.{ext}'}")
         click.echo(f"\n{summary_str or summary}")
         if title_slug:
-            new_dir = out_dir.parent / f"{out_dir.name}_{title_slug}"
-            try:
-                out_dir.rename(new_dir)
-                out_dir = new_dir
-            except Exception:
-                logging.getLogger(__name__).warning("Could not rename output directory", exc_info=True)
+            out_dir = _rename_with_title(out_dir, title_slug)
     elif not summarize:
         click.echo(f"\n{transcript_str}")
 
@@ -571,7 +612,7 @@ def run_resume(config: Config, directory: str) -> None:
         # Have transcript, missing summary — summarize only
         click.echo(f"Found transcript: {transcript}")
         click.echo("Resuming: summarize only.\n")
-        run_summarize(config, str(transcript))
+        run_summarize(config, str(transcript), in_place=True)
     else:
         # Have audio, missing transcript (and summary) — full transcribe + summarize
         click.echo(f"Found audio: {audio}")

--- a/src/ownscribe/search.py
+++ b/src/ownscribe/search.py
@@ -63,37 +63,38 @@ def ask(config: Config, question: str, since: str | None, limit: int | None) -> 
     except ImportError as exc:
         click.echo(f"Error: {exc}", err=True)
         return
-    if not summarizer.is_available():
-        click.echo("Summarization backend is not reachable. Check your configuration.")
-        return
+    with summarizer:
+        if not summarizer.is_available():
+            click.echo("Summarization backend is not reachable. Check your configuration.")
+            return
 
-    context_size = _resolve_context_size(config)
+        context_size = _resolve_context_size(config)
 
-    # Stage 1
-    label = f"Searching {len(meetings)} meetings"
-    with Spinner(label) as spinner:
-        relevant = _find_relevant_meetings(
-            summarizer, question, meetings, context_size, spinner=spinner,
-        )
-        spinner.update(label)  # restore label so exit message is clean
+        # Stage 1
+        label = f"Searching {len(meetings)} meetings"
+        with Spinner(label) as spinner:
+            relevant = _find_relevant_meetings(
+                summarizer, question, meetings, context_size, spinner=spinner,
+            )
+            spinner.update(label)  # restore label so exit message is clean
 
-    if not relevant:
-        click.echo("No relevant meetings found for your question.")
-        return
+        if not relevant:
+            click.echo("No relevant meetings found for your question.")
+            return
 
-    click.echo(f"Found {len(relevant)} relevant meetings:")
-    for m in relevant:
-        click.echo(f"  - {m.display_name}")
+        click.echo(f"Found {len(relevant)} relevant meetings:")
+        for m in relevant:
+            click.echo(f"  - {m.display_name}")
 
-    # Stage 2
-    with Spinner("Analyzing transcripts"):
-        answer, skipped_transcripts = _answer_from_transcripts(summarizer, question, relevant, context_size)
-        answer = _verify_quotes(answer, _load_transcripts(relevant))
+        # Stage 2
+        with Spinner("Analyzing transcripts"):
+            answer, skipped_transcripts = _answer_from_transcripts(summarizer, question, relevant, context_size)
+            answer = _verify_quotes(answer, _load_transcripts(relevant))
 
-    if skipped_transcripts:
-        click.echo(f"({skipped_transcripts} transcripts did not fit within context budget, they were skipped)")
+        if skipped_transcripts:
+            click.echo(f"({skipped_transcripts} transcripts did not fit within context budget, they were skipped)")
 
-    click.echo(answer)
+        click.echo(answer)
 
 
 

--- a/src/ownscribe/summarization/base.py
+++ b/src/ownscribe/summarization/base.py
@@ -26,3 +26,12 @@ class Summarizer(abc.ABC):
     @abc.abstractmethod
     def is_available(self) -> bool:
         """Check if the summarization backend is reachable."""
+
+    def close(self) -> None:  # noqa: B027 — intentional optional hook, not abstract
+        """Release any native resources. No-op by default; must be idempotent."""
+
+    def __enter__(self) -> Summarizer:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()

--- a/src/ownscribe/summarization/llama_cpp_summarizer.py
+++ b/src/ownscribe/summarization/llama_cpp_summarizer.py
@@ -108,12 +108,23 @@ class LlamaCppSummarizer(Summarizer):
         self._templates = templates or {}
         self._llm: Llama | None = None
 
-    def __del__(self) -> None:
-        """Ensure the model is properly closed on cleanup."""
-        llm = getattr(self, "_llm", None)
+    def close(self) -> None:
+        """Free the loaded model deterministically. Idempotent."""
+        llm = self._llm
+        self._llm = None
         if llm is not None:
-            with contextlib.suppress(Exception):
+            # Plain try/except, not contextlib.suppress: this runs from __del__ at
+            # interpreter shutdown when the `contextlib` global is already None.
+            try:  # noqa: SIM105
                 llm.close()
+            except Exception:
+                pass
+
+    def __del__(self) -> None:
+        try:  # noqa: SIM105
+            self.close()
+        except Exception:
+            pass
 
     def _get_llm(self) -> Llama:
         """Lazy-load the model on first use."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,28 @@ class TestMainCommand:
             assert config.audio.silence_timeout == 0
 
 
+class TestTranscribeCommand:
+    def test_summarize_flag_passes_through(self, tmp_path):
+        audio = tmp_path / "meeting.wav"
+        audio.touch()
+        runner = CliRunner()
+        with _mock_config(), mock.patch("ownscribe.pipeline.run_transcribe") as mock_run:
+            result = runner.invoke(cli, ["transcribe", str(audio), "--summarize"])
+            assert result.exit_code == 0
+            config = mock_run.call_args[0][0]
+            assert config.summarization.enabled is True
+            assert mock_run.call_args.kwargs["summarize"] is True
+
+    def test_summarize_flag_defaults_off(self, tmp_path):
+        audio = tmp_path / "meeting.wav"
+        audio.touch()
+        runner = CliRunner()
+        with _mock_config(), mock.patch("ownscribe.pipeline.run_transcribe") as mock_run:
+            result = runner.invoke(cli, ["transcribe", str(audio)])
+            assert result.exit_code == 0
+            assert mock_run.call_args.kwargs["summarize"] is False
+
+
 class TestSubcommandHelp:
     def test_transcribe_help(self):
         runner = CliRunner()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -409,18 +409,20 @@ class TestRunWarmup:
         mock_ensure.assert_not_called()
 
 
-class TestRunTranscribeColocation:
-    """Test that run_transcribe saves output alongside the input file."""
+class TestRunTranscribeOutputDir:
+    """run_transcribe copies the source into a fresh, named ownscribe output dir."""
 
-    def test_transcript_saved_next_to_audio(self, tmp_path):
+    def test_transcript_saved_in_named_output_dir(self, tmp_path):
         from ownscribe.pipeline import run_transcribe
 
-        audio_dir = tmp_path / "meetings" / "2026-01-01_1200"
-        audio_dir.mkdir(parents=True)
-        audio_path = audio_dir / "recording.wav"
+        source_dir = tmp_path / "downloads"
+        source_dir.mkdir()
+        audio_path = source_dir / "Team Meeting.wav"
         audio_path.touch()
 
+        out_base = tmp_path / "out"
         config = Config()
+        config.output.dir = str(out_base)
         config.output.format = "markdown"
 
         mock_transcriber = mock.MagicMock()
@@ -436,13 +438,81 @@ class TestRunTranscribeColocation:
         ):
             run_transcribe(config, str(audio_path))
 
-        assert (audio_dir / "transcript.md").exists()
+        assert audio_path.exists()
+        subdirs = [p for p in out_base.iterdir() if p.is_dir()]
+        assert len(subdirs) == 1
+        out_dir = subdirs[0]
+        assert out_dir.name.endswith("_team-meeting")
+        assert (out_dir / "transcript.md").exists()
+        assert (out_dir / "recording.wav").exists()
+
+    def test_transcript_in_place_when_within_output_dir(self, tmp_path):
+        from ownscribe.pipeline import run_transcribe
+
+        out_base = tmp_path / "out"
+        existing = out_base / "2026-01-01_1200_team-meeting"
+        existing.mkdir(parents=True)
+        audio_path = existing / "recording.wav"
+        audio_path.touch()
+
+        config = Config()
+        config.output.dir = str(out_base)
+        config.output.format = "markdown"
+
+        mock_transcriber = mock.MagicMock()
+        mock_transcriber.transcribe.return_value = TranscriptResult(
+            segments=[Segment(text="Test.", start=0.0, end=1.0)],
+            language="en",
+            duration=1.0,
+        )
+
+        with (
+            mock.patch("ownscribe.pipeline._create_transcriber", return_value=mock_transcriber),
+            mock.patch("ownscribe.pipeline._check_audio_silence"),
+        ):
+            run_transcribe(config, str(audio_path))
+
+        assert [p for p in out_base.iterdir() if p.is_dir()] == [existing]
+        assert (existing / "transcript.md").exists()
 
 
-class TestRunSummarizeColocation:
-    """Test that run_summarize saves output alongside the input file."""
+class TestRunSummarizeOutputDir:
+    """run_summarize copies the source into a fresh, named ownscribe output dir."""
 
-    def test_summary_saved_next_to_transcript(self, tmp_path):
+    def test_summary_saved_in_named_output_dir(self, tmp_path):
+        from ownscribe.pipeline import run_summarize
+
+        source_dir = tmp_path / "notes"
+        source_dir.mkdir()
+        tx_path = source_dir / "Standup Notes.md"
+        tx_path.write_text("# Transcript\nHello world.")
+
+        out_base = tmp_path / "out"
+        config = Config()
+        config.output.dir = str(out_base)
+        config.summarization.enabled = True
+
+        mock_summarizer = mock.MagicMock()
+        mock_summarizer.is_available.return_value = True
+        mock_summarizer.summarize.return_value = "## Summary\nGood meeting."
+        mock_summarizer.generate_title.return_value = "test-title"
+
+        with (
+            mock.patch("ownscribe.pipeline.create_summarizer", return_value=mock_summarizer),
+            mock.patch("ownscribe.summarization.llama_cpp_summarizer._ensure_model"),
+        ):
+            run_summarize(config, str(tx_path))
+
+        assert tx_path.exists()
+        subdirs = [p for p in out_base.iterdir() if p.is_dir()]
+        assert len(subdirs) == 1
+        out_dir = subdirs[0]
+        assert out_dir.name.endswith("_test-title")
+        assert "standup-notes" not in out_dir.name
+        assert (out_dir / "summary.md").exists()
+        assert (out_dir / "transcript.md").exists()
+
+    def test_in_place_summarizes_in_source_dir(self, tmp_path):
         from ownscribe.pipeline import run_summarize
 
         tx_dir = tmp_path / "meetings" / "2026-01-01_1200"
@@ -462,10 +532,38 @@ class TestRunSummarizeColocation:
             mock.patch("ownscribe.pipeline.create_summarizer", return_value=mock_summarizer),
             mock.patch("ownscribe.summarization.llama_cpp_summarizer._ensure_model"),
         ):
-            run_summarize(config, str(tx_path))
+            run_summarize(config, str(tx_path), in_place=True)
 
         renamed_dir = tx_dir.parent / f"{tx_dir.name}_test-title"
         assert (renamed_dir / "summary.md").exists()
+
+    def test_summary_in_place_when_within_output_dir(self, tmp_path):
+        from ownscribe.pipeline import run_summarize
+
+        out_base = tmp_path / "out"
+        existing = out_base / "2026-01-01_1200_team-meeting"
+        existing.mkdir(parents=True)
+        tx_path = existing / "transcript.md"
+        tx_path.write_text("# Transcript\nHello world.")
+
+        config = Config()
+        config.output.dir = str(out_base)
+        config.summarization.enabled = True
+
+        mock_summarizer = mock.MagicMock()
+        mock_summarizer.is_available.return_value = True
+        mock_summarizer.summarize.return_value = "## Summary\nGood meeting."
+        mock_summarizer.generate_title.return_value = "final-title"
+
+        with (
+            mock.patch("ownscribe.pipeline.create_summarizer", return_value=mock_summarizer),
+            mock.patch("ownscribe.summarization.llama_cpp_summarizer._ensure_model"),
+        ):
+            run_summarize(config, str(tx_path))
+
+        renamed = out_base / "2026-01-01_1200_final-title"
+        assert [p for p in out_base.iterdir() if p.is_dir()] == [renamed]
+        assert (renamed / "summary.md").exists()
 
 
 class TestResume:
@@ -498,7 +596,7 @@ class TestResume:
 
         with mock.patch("ownscribe.pipeline.run_summarize") as mock_sum:
             run_resume(config, str(tmp_path))
-            mock_sum.assert_called_once_with(config, str(tmp_path / "transcript.md"))
+            mock_sum.assert_called_once_with(config, str(tmp_path / "transcript.md"), in_place=True)
 
     def test_resumes_transcribe_and_summarize(self, tmp_path):
         from ownscribe.pipeline import run_resume
@@ -533,4 +631,4 @@ class TestResume:
 
         with mock.patch("ownscribe.pipeline.run_summarize") as mock_sum:
             run_resume(config, str(tmp_path))
-            mock_sum.assert_called_once_with(config, str(tmp_path / "transcript.json"))
+            mock_sum.assert_called_once_with(config, str(tmp_path / "transcript.json"), in_place=True)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -475,6 +475,46 @@ class TestRunTranscribeOutputDir:
         assert [p for p in out_base.iterdir() if p.is_dir()] == [existing]
         assert (existing / "transcript.md").exists()
 
+    def test_summarize_flag_also_writes_summary(self, tmp_path):
+        from ownscribe.pipeline import run_transcribe
+
+        source_dir = tmp_path / "downloads"
+        source_dir.mkdir()
+        audio_path = source_dir / "Team Meeting.wav"
+        audio_path.touch()
+
+        out_base = tmp_path / "out"
+        config = Config()
+        config.output.dir = str(out_base)
+        config.output.format = "markdown"
+        config.summarization.enabled = True
+
+        mock_transcriber = mock.MagicMock()
+        mock_transcriber.transcribe.return_value = TranscriptResult(
+            segments=[Segment(text="Test.", start=0.0, end=1.0)],
+            language="en",
+            duration=1.0,
+        )
+        mock_summarizer = mock.MagicMock()
+        mock_summarizer.is_available.return_value = True
+        mock_summarizer.summarize.return_value = "## Summary\nGood meeting."
+        mock_summarizer.generate_title.return_value = "team-sync"
+
+        with (
+            mock.patch("ownscribe.pipeline._create_transcriber", return_value=mock_transcriber),
+            mock.patch("ownscribe.pipeline.create_summarizer", return_value=mock_summarizer),
+            mock.patch("ownscribe.summarization.llama_cpp_summarizer._ensure_model"),
+            mock.patch("ownscribe.pipeline._check_audio_silence"),
+        ):
+            run_transcribe(config, str(audio_path), summarize=True)
+
+        subdirs = [p for p in out_base.iterdir() if p.is_dir()]
+        assert len(subdirs) == 1
+        out_dir = subdirs[0]
+        assert out_dir.name.endswith("_team-sync")
+        assert (out_dir / "transcript.md").exists()
+        assert (out_dir / "summary.md").exists()
+
 
 class TestRunSummarizeOutputDir:
     """run_summarize copies the source into a fresh, named ownscribe output dir."""

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -639,6 +639,80 @@ class TestLlamaCppTemplatePassthrough:
         assert "Key Concepts" in call_args[1]["messages"][1]["content"]
 
 
+class TestLlamaCppClose:
+    """Test deterministic cleanup of the local model."""
+
+    def test_close_frees_loaded_model(self, mock_llama):
+        config = SummarizationConfig(backend="local", model="phi-4-mini")
+
+        from ownscribe.summarization.llama_cpp_summarizer import LlamaCppSummarizer
+
+        summarizer = LlamaCppSummarizer(config)
+        summarizer._get_llm()
+        summarizer.close()
+
+        mock_llama.close.assert_called_once()
+        assert summarizer._llm is None
+
+    def test_close_is_idempotent(self, mock_llama):
+        config = SummarizationConfig(backend="local", model="phi-4-mini")
+
+        from ownscribe.summarization.llama_cpp_summarizer import LlamaCppSummarizer
+
+        summarizer = LlamaCppSummarizer(config)
+        summarizer._get_llm()
+        summarizer.close()
+        summarizer.close()
+
+        mock_llama.close.assert_called_once()
+
+    def test_close_without_load_is_noop(self, mock_llama):
+        config = SummarizationConfig(backend="local", model="phi-4-mini")
+
+        from ownscribe.summarization.llama_cpp_summarizer import LlamaCppSummarizer
+
+        summarizer = LlamaCppSummarizer(config)
+        summarizer.close()
+
+        mock_llama.close.assert_not_called()
+
+    def test_close_suppresses_errors(self, mock_llama):
+        mock_llama.close.side_effect = RuntimeError("boom")
+        config = SummarizationConfig(backend="local", model="phi-4-mini")
+
+        from ownscribe.summarization.llama_cpp_summarizer import LlamaCppSummarizer
+
+        summarizer = LlamaCppSummarizer(config)
+        summarizer._get_llm()
+        summarizer.close()
+
+        assert summarizer._llm is None
+
+    def test_context_manager_closes_model(self, mock_llama):
+        config = SummarizationConfig(backend="local", model="phi-4-mini")
+
+        from ownscribe.summarization.llama_cpp_summarizer import LlamaCppSummarizer
+
+        with LlamaCppSummarizer(config) as summarizer:
+            assert summarizer._get_llm() is mock_llama
+
+        mock_llama.close.assert_called_once()
+
+
+class TestSummarizerCloseContract:
+    """Backends without native resources inherit a no-op close + context manager."""
+
+    def test_ollama_close_is_noop_and_context_manager(self):
+        config = SummarizationConfig(host="http://localhost:1", backend="ollama", model="x")
+
+        from ownscribe.summarization.ollama_summarizer import OllamaSummarizer
+
+        summarizer = OllamaSummarizer(config)
+        with summarizer as entered:
+            assert entered is summarizer
+        summarizer.close()
+
+
 class TestEnsureModel:
     """Test _ensure_model with various model specifications."""
 


### PR DESCRIPTION
## Summary

Makes `ownscribe transcribe <file>` and `ownscribe summarize <file>` write into ownscribe's own output directory instead of mutating the user's source directory, and adds an optional `--summarize` flag to the `transcribe` command.

Previously both commands worked *inside* the source file's own directory and renamed it, which mutated user-owned locations (e.g. running `summarize ~/Downloads/notes.md` would rename `~/Downloads`). Now each run gets a fresh, self-contained directory.

## Key Changes

- **Dedicated output dir:** external `transcribe`/`summarize` copy the source into `<output.dir>/<timestamp>_<kebab-name>/` and write artifacts there, leaving the original untouched. The copy is renamed to the canonical `recording.<ext>` / `transcript.<ext>` so `resume` and the `_find_*` helpers keep working.
- **In-place when already managed:** if the source file already lives under the configured output dir (e.g. a prior result or a `resume` target), it's processed in place without copying, avoiding duplicates (`_within_output_dir`).
- **Post-summarize rename:** after summarizing, the directory is renamed to `<timestamp>_<kebab-description>` from the generated summary title, replacing the source-derived name (`_rename_with_title`, preserves the timestamp prefix).
- **`resume` preserved:** `run_summarize` gained an `in_place` flag so `resume` still completes an existing meeting directory in place.
- **`--summarize` flag:** `ownscribe transcribe <file> --summarize` runs summarization right after transcription, reusing the standalone summarize path. Default stays transcribe-only.

## Verification

- Automated: `ruff check src tests` ✅
- Automated: `pytest` ✅ (243 passed; includes new CLI + pipeline tests covering the new output-dir behavior, in-place detection, and the `--summarize` flag)
- Manual: reviewed resulting directory layout and rename behavior against each code path (record pipeline, external transcribe/summarize, resume).