### PR TITLE
Add [output] audio_dir to store recordings separately from transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ model = "phi-4-mini"      # local: "phi-4-mini", path to GGUF, or hf:owner/repo/
 
 [output]
 dir = "~/ownscribe"
+audio_dir = ""            # directory for audio recordings; empty = same as dir
 format = "markdown"       # "markdown" or "json"
 keep_recording = true     # false = auto-delete WAV after transcription
 ```

--- a/src/ownscribe/cli.py
+++ b/src/ownscribe/cli.py
@@ -287,15 +287,15 @@ def cleanup(
             if audio_dir != output_dir:
                 targets.append(("Audio", audio_dir))
     else:
-        targets = [
+        candidates = [
             ("Config", _CONFIG_DIR),
             ("Cache", _CACHE_DIR),
             ("Output", output_dir),
         ]
         if audio_dir != output_dir:
-            targets.append(("Audio", audio_dir))
+            candidates.append(("Audio", audio_dir))
         # Interactive: prompt for each directory
-        for label, path in targets:
+        for label, path in candidates:
             size = _dir_size(path)
             if size == "(not found)":
                 click.echo(f"  {label}: {path} — {size}, skipping")

--- a/src/ownscribe/cli.py
+++ b/src/ownscribe/cli.py
@@ -265,6 +265,7 @@ def cleanup(
     """Remove ownscribe data from disk (config, cache, recordings)."""
     cfg = ctx.obj["config"]
     output_dir = str(cfg.output.resolved_dir)
+    audio_dir = str(cfg.output.resolved_audio_dir)
 
     targets: list[tuple[str, str]] = []
 
@@ -274,6 +275,8 @@ def cleanup(
             ("Cache", _CACHE_DIR),
             ("Output", output_dir),
         ]
+        if audio_dir != output_dir:
+            targets.append(("Audio", audio_dir))
     elif config_ or cache or output:
         if config_:
             targets.append(("Config", _CONFIG_DIR))
@@ -281,13 +284,18 @@ def cleanup(
             targets.append(("Cache", _CACHE_DIR))
         if output:
             targets.append(("Output", output_dir))
+            if audio_dir != output_dir:
+                targets.append(("Audio", audio_dir))
     else:
-        # Interactive: prompt for each directory
-        for label, path in [
+        targets = [
             ("Config", _CONFIG_DIR),
             ("Cache", _CACHE_DIR),
             ("Output", output_dir),
-        ]:
+        ]
+        if audio_dir != output_dir:
+            targets.append(("Audio", audio_dir))
+        # Interactive: prompt for each directory
+        for label, path in targets:
             size = _dir_size(path)
             if size == "(not found)":
                 click.echo(f"  {label}: {path} — {size}, skipping")

--- a/src/ownscribe/config.py
+++ b/src/ownscribe/config.py
@@ -115,6 +115,9 @@ class OutputConfig:
     def resolved_audio_dir(self) -> Path:
         return Path(self.audio_dir).expanduser() if self.audio_dir else self.resolved_dir
 
+    @property
+    def uses_separate_audio_dir(self) -> bool:
+        return self.resolved_audio_dir != self.resolved_dir
 
 @dataclass
 class Config:

--- a/src/ownscribe/config.py
+++ b/src/ownscribe/config.py
@@ -49,6 +49,7 @@ model = "phi-4-mini"      # local: "phi-4-mini", path to GGUF, or hf:owner/repo/
 
 [output]
 dir = "~/ownscribe"       # base output directory
+audio_dir = ""            # directory for audio recordings; empty = same as dir
 format = "markdown"       # "markdown" or "json"
 keep_recording = true     # keep WAV files after transcription; false = auto-delete
 """
@@ -102,12 +103,17 @@ class TemplateConfig:
 @dataclass
 class OutputConfig:
     dir: str = "~/ownscribe"
+    audio_dir: str = ""
     format: str = "markdown"
     keep_recording: bool = True
 
     @property
     def resolved_dir(self) -> Path:
         return Path(self.dir).expanduser()
+
+    @property
+    def resolved_audio_dir(self) -> Path:
+        return Path(self.audio_dir).expanduser() if self.audio_dir else self.resolved_dir
 
 
 @dataclass

--- a/src/ownscribe/pipeline.py
+++ b/src/ownscribe/pipeline.py
@@ -405,7 +405,13 @@ def run_summarize(config: Config, transcript_file: str) -> None:
         # If a separate audio_dir is configured, rename like out_dir, but only
         # if audio_dir actually exists -- run_summarize can run on a transcript
         # regardless of a recording -- and if out_dir was renamed successfully.
-        if config.output.uses_separate_audio_dir:
+        # Require the transcript to live in the output tree so summarizing a
+        # transcript elsewhere cannot rename an unrelated audio directory whose
+        # name happens to match.
+        if (
+            config.output.uses_separate_audio_dir
+            and old_out_dir.parent == config.output.resolved_dir
+        ):
             audio_dir = config.output.resolved_audio_dir / old_out_dir.name
             if audio_dir.is_dir() and out_dir != old_out_dir:
                 _rename_output_dir(audio_dir, title_slug)
@@ -519,12 +525,15 @@ def _do_transcribe_and_summarize(
         if title_slug:
             out_dir, old_out_dir = _rename_output_dir(out_dir, title_slug), out_dir
             audio_dir = audio_path.parent
-            # If a separate audio_dir is configured, rename like out_dir, but
-            # only if out_dir was renamed successfully.
-            if config.output.uses_separate_audio_dir:
+            # If the audio lives in its own directory (separate audio_dir
+            # configured and the recording not colocated with the text output,
+            # as when resuming a directory recorded before audio_dir was set),
+            # rename it like out_dir, but only if out_dir was renamed
+            # successfully.
+            if config.output.uses_separate_audio_dir and audio_dir != old_out_dir:
                 if out_dir != old_out_dir:
                     audio_dir = _rename_output_dir(audio_dir, title_slug)
-            # If no separate audio_dir is configured, adjust audio_dir and
+            # Otherwise the audio follows out_dir: adjust audio_dir and
             # audio_path according to the new name of out_dir.
             else:
                 audio_dir = out_dir
@@ -538,7 +547,7 @@ def _do_transcribe_and_summarize(
         # Also remove the parent directory if it is now empty, which is expected
         # when a separate audio_dir is configured.
         if not any(audio_path.parent.iterdir()):
-            audio_path.parent.unlink()
+            audio_path.parent.rmdir()
         click.echo(f"Recording deleted (keep_recording=false): {audio_path}")
 
 

--- a/src/ownscribe/pipeline.py
+++ b/src/ownscribe/pipeline.py
@@ -401,12 +401,14 @@ def run_summarize(config: Config, transcript_file: str) -> None:
     summary_path.write_text(summary_md)
 
     if title_slug:
-        audio_dir = config.output.resolved_audio_dir / out_dir.name
         out_dir, old_out_dir = _rename_output_dir(out_dir, title_slug), out_dir
-        # Rename audio_dir only if it's separate from out_dir
-        # and if out_dir was successfully renamed.
-        if audio_dir != old_out_dir and out_dir != old_out_dir:
-            _rename_output_dir(audio_dir, title_slug)
+        # If a separate audio_dir is configured, rename like out_dir, but only
+        # if audio_dir actually exists -- run_summarize can run on a transcript
+        # regardless of a recording -- and if out_dir was renamed successfully.
+        if config.output.uses_separate_audio_dir:
+            audio_dir = config.output.resolved_audio_dir / old_out_dir.name
+            if audio_dir.is_dir() and out_dir != old_out_dir:
+                _rename_output_dir(audio_dir, title_slug)
 
     summary_path = out_dir / "summary.md"
 
@@ -515,12 +517,17 @@ def _do_transcribe_and_summarize(
         click.echo(f"Summary saved to {out_dir / f'summary.{ext}'}")
         click.echo(f"\n{summary_str or summary}")
         if title_slug:
-            audio_dir = audio_path.parent
             out_dir, old_out_dir = _rename_output_dir(out_dir, title_slug), out_dir
-            # Rename audio_dir only if it's separate from out_dir
-            # and if out_dir was successfully renamed.
-            if audio_dir != old_out_dir and out_dir != old_out_dir:
-                audio_dir = _rename_output_dir(audio_dir, title_slug)
+            audio_dir = audio_path.parent
+            # If a separate audio_dir is configured, rename like out_dir, but
+            # only if out_dir was renamed successfully.
+            if config.output.uses_separate_audio_dir:
+                if out_dir != old_out_dir:
+                    audio_dir = _rename_output_dir(audio_dir, title_slug)
+            # If no separate audio_dir is configured, adjust audio_dir and
+            # audio_path according to the new name of out_dir.
+            else:
+                audio_dir = out_dir
             audio_path = audio_dir / audio_path.name
     elif not summarize:
         click.echo(f"\n{transcript_str}")
@@ -528,6 +535,10 @@ def _do_transcribe_and_summarize(
     # Delete recording if configured — use the (possibly renamed) audio_path
     if not config.output.keep_recording and audio_path.exists():
         audio_path.unlink()
+        # Also remove the parent directory if it is now empty, which is expected
+        # when a separate audio_dir is configured.
+        if not any(audio_path.parent.iterdir()):
+            audio_path.parent.unlink()
         click.echo(f"Recording deleted (keep_recording=false): {audio_path}")
 
 
@@ -577,7 +588,7 @@ def run_resume(config: Config, directory: str) -> None:
     # explicitly resuming there. If none is found and a separate directory is
     # configured for audio, search that directory as well.
     audio = _find_audio(dir_path)
-    if audio is None:
+    if audio is None and config.output.uses_separate_audio_dir:
         candidate = config.output.resolved_audio_dir / dir_path.name
         if candidate != dir_path and candidate.is_dir():
             audio = _find_audio(candidate)

--- a/src/ownscribe/pipeline.py
+++ b/src/ownscribe/pipeline.py
@@ -66,6 +66,24 @@ def _get_output_dir(config: Config) -> Path:
     return out_dir
 
 
+def _get_output_audio_dir(config: Config, out_dir: Path) -> Path:
+    """Create and return the audio directory for a run, mirroring out_dir's name."""
+    audio_dir = config.output.resolved_audio_dir / out_dir.name
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    return audio_dir
+
+
+def _rename_output_dir(directory: Path, title_slug: str) -> Path:
+    """Append title slug to directory name. Returns the new path."""
+    new_dir = directory.parent / f"{directory.name}_{title_slug}"
+    try:
+        directory.rename(new_dir)
+        return new_dir
+    except Exception:
+        logging.getLogger(__name__).warning("Could not rename output directory", exc_info=True)
+        return directory
+
+
 def _create_recorder(config: Config):
     """Create the appropriate audio recorder based on config."""
     if config.audio.backend == "coreaudio" and not config.audio.device:
@@ -154,7 +172,8 @@ def _generate_title_slug(summary: str, summarizer) -> str:
 def run_pipeline(config: Config) -> None:
     """Run the full pipeline: record, transcribe, summarize, output."""
     out_dir = _get_output_dir(config)
-    audio_path = out_dir / "recording.wav"
+    audio_dir = _get_output_audio_dir(config, out_dir)
+    audio_path = audio_dir / "recording.wav"
 
     # 1. Record
     recorder = _create_recorder(config)
@@ -382,12 +401,12 @@ def run_summarize(config: Config, transcript_file: str) -> None:
     summary_path.write_text(summary_md)
 
     if title_slug:
-        new_dir = out_dir.parent / f"{out_dir.name}_{title_slug}"
-        try:
-            out_dir.rename(new_dir)
-            out_dir = new_dir
-        except Exception:
-            logging.getLogger(__name__).warning("Could not rename output directory", exc_info=True)
+        audio_dir = config.output.resolved_audio_dir / out_dir.name
+        out_dir, old_out_dir = _rename_output_dir(out_dir, title_slug), out_dir
+        # Rename audio_dir only if it's separate from out_dir
+        # and if out_dir was successfully renamed.
+        if audio_dir != old_out_dir and out_dir != old_out_dir:
+            _rename_output_dir(audio_dir, title_slug)
 
     summary_path = out_dir / "summary.md"
 
@@ -496,21 +515,20 @@ def _do_transcribe_and_summarize(
         click.echo(f"Summary saved to {out_dir / f'summary.{ext}'}")
         click.echo(f"\n{summary_str or summary}")
         if title_slug:
-            new_dir = out_dir.parent / f"{out_dir.name}_{title_slug}"
-            try:
-                out_dir.rename(new_dir)
-                out_dir = new_dir
-            except Exception:
-                logging.getLogger(__name__).warning("Could not rename output directory", exc_info=True)
+            audio_dir = audio_path.parent
+            out_dir, old_out_dir = _rename_output_dir(out_dir, title_slug), out_dir
+            # Rename audio_dir only if it's separate from out_dir
+            # and if out_dir was successfully renamed.
+            if audio_dir != old_out_dir and out_dir != old_out_dir:
+                audio_dir = _rename_output_dir(audio_dir, title_slug)
+            audio_path = audio_dir / audio_path.name
     elif not summarize:
         click.echo(f"\n{transcript_str}")
 
-    # Delete recording if configured — use the (possibly renamed) out_dir
-    if not config.output.keep_recording:
-        actual_audio_path = out_dir / audio_path.name
-        if actual_audio_path.exists():
-            actual_audio_path.unlink()
-            click.echo(f"Recording deleted (keep_recording=false): {actual_audio_path}")
+    # Delete recording if configured — use the (possibly renamed) audio_path
+    if not config.output.keep_recording and audio_path.exists():
+        audio_path.unlink()
+        click.echo(f"Recording deleted (keep_recording=false): {audio_path}")
 
 
 _AUDIO_EXTENSIONS = {".wav", ".mp3", ".m4a", ".flac", ".ogg", ".webm"}
@@ -555,7 +573,14 @@ def run_resume(config: Config, directory: str) -> None:
         click.echo(f"Error: {dir_path} is not a directory.", err=True)
         raise SystemExit(1)
 
+    # First look for an audio file in the target directory, since the user is
+    # explicitly resuming there. If none is found and a separate directory is
+    # configured for audio, search that directory as well.
     audio = _find_audio(dir_path)
+    if audio is None:
+        candidate = config.output.resolved_audio_dir / dir_path.name
+        if candidate != dir_path and candidate.is_dir():
+            audio = _find_audio(candidate)
     transcript = _find_transcript(dir_path)
     summary = _find_summary(dir_path)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -183,6 +183,32 @@ class TestCleanup:
         assert "Removed Cache" in result.output
         assert "Removed Output" in result.output
 
+    def test_all_yes_removes_separate_audio_dir(self, tmp_path):
+        config_dir = tmp_path / "config"
+        cache_dir = tmp_path / "cache"
+        output_dir = tmp_path / "output"
+        audio_dir = tmp_path / "audio-cache"
+        for d in (config_dir, cache_dir, output_dir, audio_dir):
+            d.mkdir()
+            (d / "file.txt").write_text("data")
+
+        cfg = Config()
+        cfg.output.dir = str(output_dir)
+        cfg.output.audio_dir = str(audio_dir)
+
+        runner = CliRunner()
+        with (
+            _mock_config(cfg),
+            mock.patch("ownscribe.cli._CONFIG_DIR", str(config_dir)),
+            mock.patch("ownscribe.cli._CACHE_DIR", str(cache_dir)),
+        ):
+            result = runner.invoke(cli, ["cleanup", "--all", "--yes"])
+
+        assert result.exit_code == 0
+        assert not output_dir.exists()
+        assert not audio_dir.exists()
+        assert "Removed Audio" in result.output
+
     def test_config_only(self, tmp_path):
         config_dir = tmp_path / "config"
         cache_dir = tmp_path / "cache"
@@ -206,6 +232,24 @@ class TestCleanup:
         assert not config_dir.exists()
         assert cache_dir.exists()
         assert output_dir.exists()
+
+    def test_output_only_also_removes_audio_dir(self, tmp_path):
+        output_dir = tmp_path / "output"
+        audio_dir = tmp_path / "audio-cache"
+        output_dir.mkdir()
+        audio_dir.mkdir()
+
+        cfg = Config()
+        cfg.output.dir = str(output_dir)
+        cfg.output.audio_dir = str(audio_dir)
+
+        runner = CliRunner()
+        with _mock_config(cfg):
+            result = runner.invoke(cli, ["cleanup", "--output", "--yes"])
+
+        assert result.exit_code == 0
+        assert not output_dir.exists()
+        assert not audio_dir.exists()
 
     def test_skips_missing_dirs(self, tmp_path):
         cfg = Config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,7 +32,6 @@ class TestDefaults:
         assert cfg.audio.mic is False
         assert cfg.audio.mic_device == ""
 
-
     def test_default_diarization_telemetry_off(self):
         cfg = Config()
         assert cfg.diarization.telemetry is False
@@ -195,3 +194,20 @@ class TestResolvedDir:
     def test_absolute_path_unchanged(self):
         cfg = OutputConfig(dir="/tmp/notes")
         assert cfg.resolved_dir == Path("/tmp/notes")
+
+
+class TestResolvedAudioDir:
+    def test_expands_tilde(self):
+        cfg = OutputConfig(dir="/tmp/notes", audio_dir="~/audio-cache")
+        resolved = cfg.resolved_audio_dir
+        assert "~" not in str(resolved)
+        assert str(resolved).endswith("audio-cache")
+
+    def test_absolute_path_unchanged(self):
+        cfg = OutputConfig(dir="/tmp/notes", audio_dir="/tmp/audio-cache")
+        assert cfg.resolved_audio_dir == Path("/tmp/audio-cache")
+        assert cfg.resolved_audio_dir != cfg.resolved_dir
+
+    def test_falls_back_to_dir_when_empty(self):
+        cfg = OutputConfig(dir="/tmp/notes", audio_dir="")
+        assert cfg.resolved_audio_dir == cfg.resolved_dir

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -339,6 +339,8 @@ class TestDoTranscribeAndSummarize:
         config = Config()
         config.output.format = "markdown"
         config.summarization.enabled = True
+        config.output.dir = str(tmp_path / "notes")
+        config.output.audio_dir = str(tmp_path / "audio-cache")
 
         out_dir = tmp_path / "notes" / "2026-01-01_1200"
         out_dir.mkdir(parents=True)
@@ -376,6 +378,8 @@ class TestDoTranscribeAndSummarize:
         config = Config()
         config.output.format = "markdown"
         config.output.keep_recording = False
+        config.output.dir = str(tmp_path / "notes")
+        config.output.audio_dir = str(tmp_path / "audio-cache")
 
         out_dir = tmp_path / "notes" / "2026-01-01_1200"
         out_dir.mkdir(parents=True)
@@ -392,6 +396,46 @@ class TestDoTranscribeAndSummarize:
 
         assert (out_dir / "transcript.md").exists()
         assert not audio_path.exists()
+        assert not audio_dir.exists()
+
+    def test_colocated_audio_follows_rename_despite_separate_audio_dir(self, tmp_path):
+        """Resuming a directory that holds its own recording (made before
+        audio_dir was configured) must follow out_dir's rename, not try to
+        rename the audio's directory a second time."""
+        from ownscribe.pipeline import _do_transcribe_and_summarize
+
+        config = Config()
+        config.output.format = "markdown"
+        config.output.keep_recording = False
+        config.summarization.enabled = True
+        config.output.dir = str(tmp_path / "notes")
+        config.output.audio_dir = str(tmp_path / "audio-cache")
+
+        out_dir = tmp_path / "notes" / "2026-01-01_1200"
+        out_dir.mkdir(parents=True)
+        audio_path = out_dir / "recording.wav"
+        audio_path.write_bytes(b"fake audio data")
+
+        mock_transcriber = mock.MagicMock()
+        mock_transcriber.transcribe.return_value = self._make_transcript()
+
+        mock_summarizer = mock.MagicMock()
+        mock_summarizer.is_available.return_value = True
+        mock_summarizer.summarize.return_value = "## Summary\nGood meeting."
+        mock_summarizer.generate_title.return_value = "Budget Review"
+
+        with (
+            mock.patch("ownscribe.pipeline._create_transcriber", return_value=mock_transcriber),
+            mock.patch("ownscribe.pipeline.create_summarizer", return_value=mock_summarizer),
+            mock.patch("ownscribe.summarization.llama_cpp_summarizer._ensure_model"),
+        ):
+            _do_transcribe_and_summarize(config, audio_path, out_dir, summarize=True)
+
+        renamed_out_dir = out_dir.parent / "2026-01-01_1200_budget-review"
+        assert (renamed_out_dir / "transcript.md").exists()
+        assert (renamed_out_dir / "summary.md").exists()
+        assert not (renamed_out_dir / "recording.wav").exists()
+        assert not out_dir.exists()
 
 
 class TestRunWarmup:
@@ -590,6 +634,72 @@ class TestRunSummarizeColocation:
 
         renamed_dir = tx_dir.parent / f"{tx_dir.name}_test-title"
         assert (renamed_dir / "summary.md").exists()
+
+    def test_renames_matching_audio_dir_inside_output_tree(self, tmp_path):
+        from ownscribe.pipeline import run_summarize
+
+        tx_dir = tmp_path / "notes" / "2026-01-01_1200"
+        tx_dir.mkdir(parents=True)
+        tx_path = tx_dir / "transcript.md"
+        tx_path.write_text("# Transcript\nHello world.")
+
+        audio_dir = tmp_path / "audio-cache" / "2026-01-01_1200"
+        audio_dir.mkdir(parents=True)
+        (audio_dir / "recording.wav").write_bytes(b"fake audio data")
+
+        config = Config()
+        config.summarization.enabled = True
+        config.output.dir = str(tmp_path / "notes")
+        config.output.audio_dir = str(tmp_path / "audio-cache")
+
+        mock_summarizer = mock.MagicMock()
+        mock_summarizer.is_available.return_value = True
+        mock_summarizer.summarize.return_value = "## Summary\nGood meeting."
+        mock_summarizer.generate_title.return_value = "test-title"
+
+        with (
+            mock.patch("ownscribe.pipeline.create_summarizer", return_value=mock_summarizer),
+            mock.patch("ownscribe.summarization.llama_cpp_summarizer._ensure_model"),
+        ):
+            run_summarize(config, str(tx_path))
+
+        renamed_audio_dir = audio_dir.parent / f"{audio_dir.name}_test-title"
+        assert (renamed_audio_dir / "recording.wav").exists()
+        assert not audio_dir.exists()
+
+    def test_leaves_audio_dir_alone_for_transcript_outside_output_tree(self, tmp_path):
+        """A same-named directory under audio_dir must not be renamed when the
+        summarized transcript does not belong to the output tree."""
+        from ownscribe.pipeline import run_summarize
+
+        tx_dir = tmp_path / "elsewhere" / "2026-01-01_1200"
+        tx_dir.mkdir(parents=True)
+        tx_path = tx_dir / "transcript.md"
+        tx_path.write_text("# Transcript\nHello world.")
+
+        unrelated_audio_dir = tmp_path / "audio-cache" / "2026-01-01_1200"
+        unrelated_audio_dir.mkdir(parents=True)
+
+        config = Config()
+        config.summarization.enabled = True
+        config.output.dir = str(tmp_path / "notes")
+        config.output.audio_dir = str(tmp_path / "audio-cache")
+
+        mock_summarizer = mock.MagicMock()
+        mock_summarizer.is_available.return_value = True
+        mock_summarizer.summarize.return_value = "## Summary\nGood meeting."
+        mock_summarizer.generate_title.return_value = "test-title"
+
+        with (
+            mock.patch("ownscribe.pipeline.create_summarizer", return_value=mock_summarizer),
+            mock.patch("ownscribe.summarization.llama_cpp_summarizer._ensure_model"),
+        ):
+            run_summarize(config, str(tx_path))
+
+        renamed_dir = tx_dir.parent / f"{tx_dir.name}_test-title"
+        assert (renamed_dir / "summary.md").exists()
+        assert unrelated_audio_dir.exists()
+        assert not (unrelated_audio_dir.parent / f"{tx_dir.name}_test-title").exists()
 
 
 class TestResume:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -333,6 +333,66 @@ class TestDoTranscribeAndSummarize:
         assert "Hello world." in (tmp_path / "transcript.md").read_text()
         assert not (tmp_path / "summary.md").exists()
 
+    def test_separate_audio_dir_renamed_alongside_out_dir(self, tmp_path):
+        from ownscribe.pipeline import _do_transcribe_and_summarize
+
+        config = Config()
+        config.output.format = "markdown"
+        config.summarization.enabled = True
+
+        out_dir = tmp_path / "notes" / "2026-01-01_1200"
+        out_dir.mkdir(parents=True)
+        audio_dir = tmp_path / "audio-cache" / "2026-01-01_1200"
+        audio_dir.mkdir(parents=True)
+        audio_path = audio_dir / "recording.wav"
+        audio_path.write_bytes(b"fake audio data")
+
+        mock_transcriber = mock.MagicMock()
+        mock_transcriber.transcribe.return_value = self._make_transcript()
+
+        mock_summarizer = mock.MagicMock()
+        mock_summarizer.is_available.return_value = True
+        mock_summarizer.summarize.return_value = "## Summary\nGood meeting."
+        mock_summarizer.generate_title.return_value = "Budget Review"
+
+        with (
+            mock.patch("ownscribe.pipeline._create_transcriber", return_value=mock_transcriber),
+            mock.patch("ownscribe.pipeline.create_summarizer", return_value=mock_summarizer),
+            mock.patch("ownscribe.summarization.llama_cpp_summarizer._ensure_model"),
+        ):
+            _do_transcribe_and_summarize(config, audio_path, out_dir, summarize=True)
+
+        renamed_out_dir = out_dir.parent / "2026-01-01_1200_budget-review"
+        renamed_audio_dir = audio_dir.parent / "2026-01-01_1200_budget-review"
+        assert (renamed_out_dir / "transcript.md").exists()
+        assert (renamed_out_dir / "summary.md").exists()
+        assert (renamed_audio_dir / "recording.wav").exists()
+        assert not out_dir.exists()
+        assert not audio_dir.exists()
+
+    def test_keep_recording_false_deletes_from_separate_audio_dir(self, tmp_path):
+        from ownscribe.pipeline import _do_transcribe_and_summarize
+
+        config = Config()
+        config.output.format = "markdown"
+        config.output.keep_recording = False
+
+        out_dir = tmp_path / "notes" / "2026-01-01_1200"
+        out_dir.mkdir(parents=True)
+        audio_dir = tmp_path / "audio-cache" / "2026-01-01_1200"
+        audio_dir.mkdir(parents=True)
+        audio_path = audio_dir / "recording.wav"
+        audio_path.write_bytes(b"fake audio data")
+
+        mock_transcriber = mock.MagicMock()
+        mock_transcriber.transcribe.return_value = self._make_transcript()
+
+        with mock.patch("ownscribe.pipeline._create_transcriber", return_value=mock_transcriber):
+            _do_transcribe_and_summarize(config, audio_path, out_dir, summarize=False)
+
+        assert (out_dir / "transcript.md").exists()
+        assert not audio_path.exists()
+
 
 class TestRunWarmup:
     def test_run_warmup_calls_prepare_models(self):
@@ -407,6 +467,70 @@ class TestRunWarmup:
             run_warmup(config)
 
         mock_ensure.assert_not_called()
+
+
+class TestRunPipelineAudioLocation:
+    """Test that run_pipeline records into the configured audio_dir."""
+
+    def _make_recorder_mock(self):
+        recorder = mock.MagicMock()
+        recorder.is_recording = False  # skip the recording loop immediately
+        recorder.is_muted = False
+        recorder.silence_timed_out = False
+        recorder.silence_warning = False
+
+        def _start(path):
+            # Must exceed _WAV_HEADER_SIZE (44 bytes) or run_pipeline treats it as empty.
+            path.write_bytes(b"fake audio data, definitely more than 44 bytes")
+
+        recorder.start.side_effect = _start
+        return recorder
+
+    def test_audio_recorded_into_separate_audio_dir(self, tmp_path):
+        from ownscribe.pipeline import run_pipeline
+
+        config = Config()
+        config.output.dir = str(tmp_path / "notes")
+        config.output.audio_dir = str(tmp_path / "audio-cache")
+
+        mock_recorder = self._make_recorder_mock()
+
+        with (
+            mock.patch("ownscribe.pipeline._create_recorder", return_value=mock_recorder),
+            mock.patch("ownscribe.pipeline._do_transcribe_and_summarize") as mock_ts,
+        ):
+            run_pipeline(config)
+
+        # The recorder was pointed at a file under audio_dir, not dir.
+        audio_path = mock_recorder.start.call_args[0][0]
+        assert audio_path.is_relative_to(tmp_path / "audio-cache")
+        assert not audio_path.is_relative_to(tmp_path / "notes")
+        assert audio_path.exists()
+
+        # Downstream processing still receives the audio dir's out_dir counterpart.
+        called_audio_path, called_out_dir = mock_ts.call_args[0][1], mock_ts.call_args[0][2]
+        assert called_audio_path == audio_path
+        assert called_out_dir.is_relative_to(tmp_path / "notes")
+        assert called_out_dir.name == audio_path.parent.name
+
+    def test_audio_recorded_into_dir_when_audio_dir_unset(self, tmp_path):
+        from ownscribe.pipeline import run_pipeline
+
+        config = Config()
+        config.output.dir = str(tmp_path / "notes")
+        config.output.audio_dir = ""
+
+        mock_recorder = self._make_recorder_mock()
+
+        with (
+            mock.patch("ownscribe.pipeline._create_recorder", return_value=mock_recorder),
+            mock.patch("ownscribe.pipeline._do_transcribe_and_summarize"),
+        ):
+            run_pipeline(config)
+
+        audio_path = mock_recorder.start.call_args[0][0]
+        assert audio_path.is_relative_to(tmp_path / "notes")
+        assert audio_path.parent.parent == tmp_path / "notes"
 
 
 class TestRunTranscribeColocation:
@@ -523,6 +647,24 @@ class TestResume:
         with mock.patch("ownscribe.pipeline._do_transcribe_and_summarize") as mock_ts:
             run_resume(config, str(tmp_path))
             mock_ts.assert_called_once_with(config, audio_path, tmp_path)
+
+    def test_finds_audio_in_separate_audio_dir(self, tmp_path):
+        from ownscribe.pipeline import run_resume
+
+        text_dir = tmp_path / "notes" / "2026-01-01_1200"
+        text_dir.mkdir(parents=True)
+        audio_dir = tmp_path / "audio-cache" / "2026-01-01_1200"
+        audio_dir.mkdir(parents=True)
+        audio_path = audio_dir / "recording.wav"
+        audio_path.touch()
+
+        config = Config()
+        config.output.dir = str(tmp_path / "notes")
+        config.output.audio_dir = str(tmp_path / "audio-cache")
+
+        with mock.patch("ownscribe.pipeline._do_transcribe_and_summarize") as mock_ts:
+            run_resume(config, str(text_dir))
+            mock_ts.assert_called_once_with(config, audio_path, text_dir)
 
     def test_finds_json_transcript(self, tmp_path):
         from ownscribe.pipeline import run_resume


### PR DESCRIPTION
Audio is a disposable cache once transcription succeeds, while transcripts and summaries are the real output worth syncing across devices and backing up. Storing the audio elsewhere avoids overloading a sync or backup system with uncompressed audio files.

audio_dir defaults to empty (same as dir, current behavior) and, when set, keeps the audio directory in sync with the standard output directory's timestamp name and title-slug rename across the record, transcribe, summarize, resume, and cleanup flows.